### PR TITLE
WFNEWS-537 debounce fix

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/store/incidents/incidents.effects.ts
+++ b/client/wfnews-war/src/main/angular/src/app/store/incidents/incidents.effects.ts
@@ -25,7 +25,7 @@ export class IncidentsEffect {
     getIncidentList: Observable<Action> = this.actions.pipe(
         ofType(SEARCH_INCIDENTS),
         withLatestFrom(this.store),
-        debounceTime(500),
+        debounceTime(1000),
         switchMap(
             ([action, store]) => {
 


### PR DESCRIPTION
After further research, seems like the culprit of this behavior in the first place, was the TokenService js class having a setTimeOut with 0 seconds in initAndEmit() method. setTimeOut with zero seconds, basically means that the execution will happen after the next event cycle in the browser event loop (which is never 0 seconds, btw). Debouncing 1000ms instead of 500ms seems to do the trick.