### PR TITLE
Add radius query

### DIFF
--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/PublicPublishedIncidentEndpoint.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/PublicPublishedIncidentEndpoint.java
@@ -31,7 +31,10 @@ public interface PublicPublishedIncidentEndpoint extends BaseEndpoints{
 		@ApiParam("Filter on fire of note") @QueryParam("fireOfNote") Boolean fireOfNote,
 		@ApiParam("Filter on fires that are Out") @QueryParam("out") Boolean out,
 		@ApiParam("Filter on fire centre") @QueryParam("fireCentre") String fireCentre,
-		@ApiParam("The Bounding box to restrict the query to, comma delimited xmin, ymin, xmax, ymax") @QueryParam("bbox") String bbox) throws NotFoundException, ForbiddenException, ConflictException;
+		@ApiParam("The Bounding box to restrict the query to, comma delimited xmin, ymin, xmax, ymax") @QueryParam("bbox") String bbox,
+		@ApiParam("The latitude for a point and radius query") @QueryParam("latitude") Double latitude,
+		@ApiParam("The longitude for a point and radius query") @QueryParam("longitude") Double longitude,
+		@ApiParam("The radius (in metres) for a point and radius query") @QueryParam("radius") Double radius) throws NotFoundException, ForbiddenException, ConflictException;
 	
 	@GET
 	@Path("/features")

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/PublicPublishedIncidentEndpointImpl.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/PublicPublishedIncidentEndpointImpl.java
@@ -35,7 +35,7 @@ public class PublicPublishedIncidentEndpointImpl extends BaseEndpointsImpl imple
 	private ParameterValidator parameterValidator;
 	
 	@Override
-	public Response getPublishedIncidentList(String searchText, String pageNumber, String pageRowCount, String orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox) throws NotFoundException, ForbiddenException, ConflictException {
+	public Response getPublishedIncidentList(String searchText, String pageNumber, String pageRowCount, String orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox, Double latitude, Double longitude, Double radius) throws NotFoundException, ForbiddenException, ConflictException {
 		Response response = null;
 		
 		try {
@@ -52,37 +52,36 @@ public class PublicPublishedIncidentEndpointImpl extends BaseEndpointsImpl imple
 			
 			List<Message> validationMessages = this.parameterValidator.validatePagingQueryParameters(parameters);
 
-			if (bbox == null) {
-				bbox = "-139.06,48.30,-114.03,60.00";
-			}
-
-			String[] coords = bbox.split(",");
-			boolean invalidBox = false;
-			if (coords.length != 4) {
-				invalidBox = true;
-			} else {
-				for (String coord : coords) {
-					try {
-						Double.parseDouble(coord);
-					} catch (Exception e) {
-						invalidBox = true;
-						break;
+			if (bbox != null) {
+				String[] coords = bbox.split(",");
+				boolean invalidBox = false;
+				if (coords.length != 4) {
+					invalidBox = true;
+				} else {
+					for (String coord : coords) {
+						try {
+							Double.parseDouble(coord);
+						} catch (Exception e) {
+							invalidBox = true;
+							break;
+						}
 					}
 				}
-			}
 
-			if (invalidBox) {
-				Message message = new MessageImpl();
-				message.setPath("bbox");
-				message.setMessage("BBox contains invalid coordinate set");
-				validationMessages.add(message);
+				if (invalidBox) {
+					Message message = new MessageImpl();
+					message.setPath("bbox");
+					message.setMessage("BBox contains invalid coordinate set");
+					validationMessages.add(message);
+					bbox = null;
+				}
 			}
 
 			if (!validationMessages.isEmpty()) {
 				response = Response.status(Status.BAD_REQUEST).entity(validationMessages).build();
 			}else {
 
-				PublishedIncidentListResource results = incidentsService.getPublishedIncidentList(searchText, pageNum, rowCount, orderBy, fireOfNote, out, fireCentre, bbox, getFactoryContext());
+				PublishedIncidentListResource results = incidentsService.getPublishedIncidentList(searchText, pageNum, rowCount, orderBy, fireOfNote, out, fireCentre, bbox, latitude, longitude, radius, getFactoryContext());
 
 				GenericEntity<PublishedIncidentListResource> entity = new GenericEntity<PublishedIncidentListResource>(results) {
 					/* do nothing */

--- a/server/wfnews-persistence/src/main/java/ca/bc/gov/nrs/wfnews/persistence/v1/dao/PublishedIncidentDao.java
+++ b/server/wfnews-persistence/src/main/java/ca/bc/gov/nrs/wfnews/persistence/v1/dao/PublishedIncidentDao.java
@@ -32,7 +32,7 @@ public interface PublishedIncidentDao extends Serializable {
 
 	void flush() throws DaoException;
 
-	PagedDtos<PublishedIncidentDto> select(String searchText, Integer pageNumber, Integer pageRowCount, List<String> orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox) throws DaoException;
+	PagedDtos<PublishedIncidentDto> select(String searchText, Integer pageNumber, Integer pageRowCount, List<String> orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox, Double latitude, Double longitude, Double radius) throws DaoException;
 
 	String selectAsJson(String stageOfControlCode, String bbox) throws DaoException;
 	

--- a/server/wfnews-persistence/src/main/java/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/PublishedIncidentDaoImpl.java
+++ b/server/wfnews-persistence/src/main/java/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/PublishedIncidentDaoImpl.java
@@ -201,13 +201,13 @@ public class PublishedIncidentDaoImpl extends BaseDao implements
 	}
 
 	@Override
-	public PagedDtos<PublishedIncidentDto> select(String searchText, Integer pageNumber, Integer pageRowCount, List<String> orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox) throws DaoException{
+	public PagedDtos<PublishedIncidentDto> select(String searchText, Integer pageNumber, Integer pageRowCount, List<String> orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox, Double latitude, Double longitude, Double radius) throws DaoException{
 		
 		PagedDtos<PublishedIncidentDto> results = new PagedDtos<>();
 		
 		try {
 
-			Map<String, Object> parameters = new HashMap<String, Object>();
+			Map<String, Object> parameters = new HashMap<>();
 			
 			Integer offset = null;
 			
@@ -226,10 +226,13 @@ public class PublishedIncidentDaoImpl extends BaseDao implements
 			parameters.put("fireOfNote", fireOfNote);
 			parameters.put("out", out);
 			parameters.put("fireCentre", fireCentre);
-			parameters.put("xmin", Double.parseDouble(bbox.split(",")[0]));
-			parameters.put("ymin", Double.parseDouble(bbox.split(",")[1]));
-			parameters.put("xmax", Double.parseDouble(bbox.split(",")[2]));
-			parameters.put("ymax", Double.parseDouble(bbox.split(",")[3]));
+			parameters.put("xmin", bbox != null ? Double.parseDouble(bbox.split(",")[0]) : null);
+			parameters.put("ymin", bbox != null ? Double.parseDouble(bbox.split(",")[1]) : null);
+			parameters.put("xmax", bbox != null ? Double.parseDouble(bbox.split(",")[2]) : null);
+			parameters.put("ymax", bbox != null ? Double.parseDouble(bbox.split(",")[3]) : null);
+			parameters.put("latitude", latitude);
+			parameters.put("longitude", longitude);
+			parameters.put("radius", radius);
 			parameters.put("searchText", searchText);
 
 			List<PublishedIncidentDto> dtos = this.publishedIncidentMapper.select(parameters);

--- a/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/AttachmentMapper.xml
+++ b/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/AttachmentMapper.xml
@@ -118,7 +118,7 @@
 	    WHERE file_attachment_guid = {fileAttachmentGuid, javaType=java.lang.String, jdbcType=BINARY, mode=IN};
   </update>
 
-  <select id="fetch" resultMap="ExternalUriDtoMap"> 
+  <select id="fetch" resultMap="AttachmentDtoMap"> 
 		SELECT *
       FROM wfnews.file_attachment f
       JOIN wfnews.file_attachment_metadata m
@@ -135,7 +135,7 @@
 		WHERE file_attachment_guid = {fileAttachmentGuid, javaType=java.lang.String, jdbcType=BINARY, mode=IN};
 	</delete>
 
-  <select id="select" resultMap="ExternalUriDtoMap">
+  <select id="select" resultMap="AttachmentDtoMap">
   	SELECT *
       FROM wfnews.file_attachment f
       JOIN wfnews.file_attachment_metadata m

--- a/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/PublishedIncidentMapper.xml
+++ b/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/PublishedIncidentMapper.xml
@@ -251,7 +251,7 @@
 				AND geometry &amp;&amp; ST_MakeEnvelope (#{xmin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{xmax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, 4326)
 			</if>
 			<if test="latitude != null &amp;&amp; longitude != null &amp;&amp; radius != null">
-				AND ST_DWithin(s.geometry, ST_SetSRID(ST_MakePoint(#{longitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{latitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}), 4326), #{radius, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN})
+				AND ST_DWithin(geometry, ST_SetSRID(ST_MakePoint(#{longitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{latitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}), 4326), #{radius, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN})
 			</if>
 		  <if test="out == true">  
 				AND stage_of_control_code = 'OUT'

--- a/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/PublishedIncidentMapper.xml
+++ b/server/wfnews-persistence/src/main/resources/ca/bc/gov/nrs/wfnews/persistence/v1/dao/mybatis/mapper/PublishedIncidentMapper.xml
@@ -246,7 +246,13 @@
 
 		SELECT *
 		  FROM WFNEWS.PUBLISHED_INCIDENT_DETAIL
-			WHERE geometry &amp;&amp; ST_MakeEnvelope (#{xmin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{xmax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, 4326)
+			WHERE 1=1
+			<if test="xmin != null &amp;&amp; ymin != null &amp;&amp; xmax != null &amp;&amp; ymax != null">
+				AND geometry &amp;&amp; ST_MakeEnvelope (#{xmin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymin, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{xmax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{ymax, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, 4326)
+			</if>
+			<if test="latitude != null &amp;&amp; longitude != null &amp;&amp; radius != null">
+				AND ST_DWithin(s.geometry, ST_SetSRID(ST_MakePoint(#{longitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}, #{latitude, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN}), 4326), #{radius, javaType=java.lang.Double, jdbcType=DOUBLE, mode=IN})
+			</if>
 		  <if test="out == true">  
 				AND stage_of_control_code = 'OUT'
 			</if>

--- a/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/IncidentsService.java
+++ b/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/IncidentsService.java
@@ -55,7 +55,7 @@ public interface IncidentsService {
 	void flush(FactoryContext factoryContext) throws NotFoundException, ConflictException;
 
 	@Transactional(readOnly = true, rollbackFor=Exception.class)
-	PublishedIncidentListResource getPublishedIncidentList(String searchText, Integer pageNumber, Integer pageRowCount, String orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox, FactoryContext factoryContext);
+	PublishedIncidentListResource getPublishedIncidentList(String searchText, Integer pageNumber, Integer pageRowCount, String orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox, Double latitude, Double longitude, Double radius, FactoryContext factoryContext);
 
 	@Transactional(readOnly = false, rollbackFor=Exception.class)
 	ExternalUriResource createExternalUri(ExternalUriResource externalUri, FactoryContext factoryContext) throws ValidationFailureException, ConflictException, NotFoundException, Exception;

--- a/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/impl/IncidentsServiceImpl.java
+++ b/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/impl/IncidentsServiceImpl.java
@@ -473,7 +473,7 @@ public class IncidentsServiceImpl extends BaseEndpointsImpl implements Incidents
 	@Override
 	public PublishedIncidentListResource getPublishedIncidentList(String searchText, Integer pageNumber,
 			Integer pageRowCount, String orderBy, Boolean fireOfNote, Boolean out, String fireCentre, String bbox,
-			FactoryContext factoryContext) {
+			Double latitude, Double longitude, Double radius, FactoryContext factoryContext) {
 		PublishedIncidentListResource results = null;
 		PagedDtos<PublishedIncidentDto> publishedIncidentList = new PagedDtos<>();
 		try {
@@ -508,7 +508,7 @@ public class IncidentsServiceImpl extends BaseEndpointsImpl implements Incidents
 			}
 
 			publishedIncidentList = this.publishedIncidentDao.select(searchText, pageNumber, pageRowCount, orderByList,
-					fireOfNote, out, fireCentre, bbox);
+					fireOfNote, out, fireCentre, bbox, latitude, longitude, radius);
 			results = this.publishedIncidentFactory.getPublishedIncidentList(publishedIncidentList, pageNumber, pageRowCount,
 					factoryContext);
 		} catch (DaoException e) {


### PR DESCRIPTION
Added a query for published incidents.

You can add query attributes on the request for `longitude`, `latitude`, and 'radius`. This shouldn't be used in conjunction with the bbox query. Radius is in metres.