### PR TITLE
WFNEWS 624: Initial API Side SNS message implementation

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/sticky-widget/contact-widget-dialog/contact-widget-dialog.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/sticky-widget/contact-widget-dialog/contact-widget-dialog.component.ts
@@ -67,6 +67,8 @@ export class ContactWidgetDialogComponent implements OnInit {
           message: this.contactForm.get('message')
         }).toPromise().then(() => {
           this.snackbarService.open('Thank you! Our Team will contact you as soon as possible.', null, { duration: 10000, panelClass: 'snackbar-success-v2' });
+        }).catch(err => {
+          this.snackbarService.open('Your request could not be processed at this time. Please try again later.', null, { duration: 10000, panelClass: 'snackbar-error' });
         })
     }
 }

--- a/client/wfnews-war/src/main/angular/src/app/components/sticky-widget/contact-widget-dialog/contact-widget-dialog.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/sticky-widget/contact-widget-dialog/contact-widget-dialog.component.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -17,7 +18,8 @@ export class ContactWidgetDialogComponent implements OnInit {
     constructor (
       private dialogRef: MatDialogRef<ContactWidgetDialogComponent>,
       private snackbarService: MatSnackBar,
-      private appConfig: AppConfigService
+      private appConfig: AppConfigService,
+      private httpClient: HttpClient
     ) {}
 
     ngOnInit() {
@@ -49,13 +51,22 @@ export class ContactWidgetDialogComponent implements OnInit {
             error += "Email is required";
         if(emailControl.hasError('email'))
             error += "A valid email is required";
-        
+
         return error;
      }
 
     onSubmit() {
         //TODO: send to email API
         this.dialogRef.close();
-        this.snackbarService.open('Thank you! Our Team will contact you as soon as possible.', null, { duration: 10000, panelClass: 'snackbar-success-v2' });
+        const url = `${this.appConfig.getConfig().rest['wfnews']}/mail`;
+
+        this.httpClient.post(url, {
+          name: this.contactForm.get('name'),
+          subject: this.contactForm.get('subject'),
+          emailAddress: this.contactForm.get('email'),
+          message: this.contactForm.get('message')
+        }).toPromise().then(() => {
+          this.snackbarService.open('Thank you! Our Team will contact you as soon as possible.', null, { duration: 10000, panelClass: 'snackbar-success-v2' });
+        })
     }
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -266,6 +266,12 @@
 			    <scope>test</scope>
 			</dependency>
 
+			<!-- AWS -->
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>sns</artifactId>
+				<version>2.18.9</version>
+			</dependency>
 
 		</dependencies>
 	</dependencyManagement>

--- a/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
+++ b/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
@@ -7,7 +7,7 @@ import ca.bc.gov.nrs.common.wfone.rest.resource.BaseResource;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.types.ResourceTypes;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
-@JsonTypeName(ResourceTypes.INCIDENT)
+@JsonTypeName(ResourceTypes.MAIL)
 public class MailResource extends BaseResource {
   private static final long serialVersionUID = 1L;
 

--- a/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
+++ b/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
@@ -6,6 +6,10 @@ import org.codehaus.jackson.annotate.JsonTypeName;
 import ca.bc.gov.nrs.common.wfone.rest.resource.BaseResource;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.types.ResourceTypes;
 
+/**
+ * Information Request Mail Resource
+ * This resource should only be used for the Mail to SNS handler
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
 @JsonTypeName(ResourceTypes.MAIL)
 public class MailResource extends BaseResource {

--- a/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
+++ b/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/MailResource.java
@@ -1,0 +1,54 @@
+package ca.bc.gov.nrs.wfnews.api.rest.v1.resource;
+
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.annotate.JsonTypeName;
+
+import ca.bc.gov.nrs.common.wfone.rest.resource.BaseResource;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.types.ResourceTypes;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
+@JsonTypeName(ResourceTypes.INCIDENT)
+public class MailResource extends BaseResource {
+  private static final long serialVersionUID = 1L;
+
+  private String name;
+  private String emailAddress;
+  private String subject;
+  private String messageBody;
+
+  public MailResource() { }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmailAddress() {
+    return emailAddress;
+  }
+
+  public void setEmailAddress(String emailAddress) {
+    this.emailAddress = emailAddress;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public String getMessageBody() {
+    return messageBody;
+  }
+
+  public void setMessageBody(String messageBody) {
+    this.messageBody = messageBody;
+  }
+
+  
+}

--- a/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/types/ResourceTypes.java
+++ b/server/wfnews-api-rest-common/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/resource/types/ResourceTypes.java
@@ -13,6 +13,9 @@ public class ResourceTypes extends BaseResourceTypes {
 	public static final String ATTACHMENT_LIST_NAME = "attachmentList";
 	public static final String ATTACHMENT_LIST = NAMESPACE + ATTACHMENT_LIST_NAME;
 	
+	public static final String MAIL_NAME = "mail";
+	public static final String MAIL = NAMESPACE + MAIL_NAME;
+
 	public static final String INCIDENT_NAME = "incident";
 	public static final String INCIDENT = NAMESPACE + INCIDENT_NAME;
 	

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
@@ -1,37 +1,19 @@
 package ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import ca.bc.gov.nrs.common.rest.resource.HeaderConstants;
-import ca.bc.gov.nrs.common.wfone.rest.resource.MessageListRsrc;
-import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.security.Scopes;
-import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.AttachmentResource;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
-import io.swagger.annotations.Extension;
-import io.swagger.annotations.ExtensionProperty;
-import io.swagger.annotations.ResponseHeader;
 import ca.bc.gov.nrs.common.rest.endpoints.BaseEndpoints;
 import ca.bc.gov.nrs.common.service.ConflictException;
 import ca.bc.gov.nrs.common.service.ForbiddenException;
 import ca.bc.gov.nrs.common.service.NotFoundException;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 
 @Api(value = "mail")
 @Path("/mail")

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
@@ -15,6 +15,11 @@ import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 
+/**
+ * Mail Endpoint for sending information requests to SNS
+ * This is a public resource, so no security check is needed
+ * Mail resource will support XML or JSON
+ */
 @Api(value = "mail")
 @Path("/mail")
 public interface MailEndpoint extends BaseEndpoints {

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/MailEndpoint.java
@@ -1,0 +1,43 @@
+package ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import ca.bc.gov.nrs.common.rest.resource.HeaderConstants;
+import ca.bc.gov.nrs.common.wfone.rest.resource.MessageListRsrc;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.security.Scopes;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.AttachmentResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
+import io.swagger.annotations.ResponseHeader;
+import ca.bc.gov.nrs.common.rest.endpoints.BaseEndpoints;
+import ca.bc.gov.nrs.common.service.ConflictException;
+import ca.bc.gov.nrs.common.service.ForbiddenException;
+import ca.bc.gov.nrs.common.service.NotFoundException;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
+
+@Api(value = "mail")
+@Path("/mail")
+public interface MailEndpoint extends BaseEndpoints {
+  @POST
+	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+	@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+	public Response sendMail(@ApiParam(name = "mail", value = "The email details", required = true) MailResource mail) throws NotFoundException, ForbiddenException, ConflictException;
+}

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/MailEndpointImpl.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/MailEndpointImpl.java
@@ -1,34 +1,18 @@
 package ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl;
 
-import java.net.URI;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import ca.bc.gov.nrs.common.persistence.dao.DaoException;
-import ca.bc.gov.nrs.wfone.common.rest.endpoints.BaseEndpointsImpl;
-import ca.bc.gov.nrs.wfone.common.service.api.ServiceException;
 import ca.bc.gov.nrs.common.service.ConflictException;
 import ca.bc.gov.nrs.common.service.ForbiddenException;
 import ca.bc.gov.nrs.common.service.NotFoundException;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.MailEndpoint;
-import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.PublishedIncidentEndpoint;
-import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.security.Scopes;
-import ca.bc.gov.nrs.wfnews.api.rest.v1.parameters.validation.ParameterValidator;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
-import ca.bc.gov.nrs.wfnews.api.model.v1.PublishedIncident;
 import ca.bc.gov.nrs.wfnews.service.api.v1.EmailNotificationService;
-import ca.bc.gov.nrs.wfnews.service.api.v1.IncidentsService;
-import ca.bc.gov.nrs.wfnews.service.api.v1.validation.exception.ValidationException;
+import ca.bc.gov.nrs.wfone.common.rest.endpoints.BaseEndpointsImpl;
 
 public class MailEndpointImpl extends BaseEndpointsImpl implements MailEndpoint {
   private static final Logger logger = LoggerFactory.getLogger(MailEndpointImpl.class);

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/MailEndpointImpl.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/MailEndpointImpl.java
@@ -1,0 +1,57 @@
+package ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ca.bc.gov.nrs.common.persistence.dao.DaoException;
+import ca.bc.gov.nrs.wfone.common.rest.endpoints.BaseEndpointsImpl;
+import ca.bc.gov.nrs.wfone.common.service.api.ServiceException;
+import ca.bc.gov.nrs.common.service.ConflictException;
+import ca.bc.gov.nrs.common.service.ForbiddenException;
+import ca.bc.gov.nrs.common.service.NotFoundException;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.MailEndpoint;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.PublishedIncidentEndpoint;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.security.Scopes;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.parameters.validation.ParameterValidator;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
+import ca.bc.gov.nrs.wfnews.api.model.v1.PublishedIncident;
+import ca.bc.gov.nrs.wfnews.service.api.v1.EmailNotificationService;
+import ca.bc.gov.nrs.wfnews.service.api.v1.IncidentsService;
+import ca.bc.gov.nrs.wfnews.service.api.v1.validation.exception.ValidationException;
+
+public class MailEndpointImpl extends BaseEndpointsImpl implements MailEndpoint {
+  private static final Logger logger = LoggerFactory.getLogger(MailEndpointImpl.class);
+
+  @Autowired
+	private EmailNotificationService emailNotificationService;
+
+  @Override
+  public Response sendMail(MailResource mail) throws NotFoundException, ForbiddenException, ConflictException {
+    logger.debug(" >> sendMail");
+    logger.debug("    Name: {}", mail.getName());
+    logger.debug("    Subject: {}", mail.getSubject());
+    logger.debug("    Address: {}", mail.getEmailAddress());
+    try {
+      if (emailNotificationService.sendMessage(mail)) {
+        return Response.ok("{ messageStatus: 'SENT', response: 'Your information request has been successfully delivered.' }").build();
+      } else {
+        return Response.ok("{ messageStatus: 'UNSENT', response: 'Your information request could not be sent at this time' }").build();
+      }
+    } catch(Throwable t) {
+      return getInternalServerErrorResponse(t);
+    } finally {
+      logger.debug(" << sendMail");
+    }
+  }
+}

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/jersey/JerseyApplication.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/jersey/JerseyApplication.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.AttachmentsEndpointImpl;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.AttachmentsListEndpointImpl;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.ExternalUriEndpointImpl;
+import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.MailEndpointImpl;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.PublicExternalUriEndpointImpl;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.PublicPublishedIncidentEndpointImpl;
 import ca.bc.gov.nrs.wfnews.api.rest.v1.endpoints.impl.PublishedIncidentEndpointImpl;
@@ -46,6 +47,7 @@ public class JerseyApplication extends JerseyResourceConfig {
 		register(PublicExternalUriEndpointImpl.class);
 		register(AttachmentsListEndpointImpl.class);
 		register(AttachmentsEndpointImpl.class);
+		register(MailEndpointImpl.class);
 
 		SwaggerConfiguration oasConfig = new SwaggerConfiguration()
 			.prettyPrint(Boolean.TRUE)

--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/spring/SecuritySpringConfig.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/spring/SecuritySpringConfig.java
@@ -80,6 +80,7 @@ public class SecuritySpringConfig extends WebSecurityConfigurerAdapter  {
 		.antMatchers(HttpMethod.GET, "/publicPublishedIncident/**")
 		.antMatchers(HttpMethod.GET, "/publicPublishedIncidentAttachment/**")
 		.antMatchers(HttpMethod.GET, "/publicExternalUri/**")
+		.antMatchers(HttpMethod.GET, "/mail/**")
 		.antMatchers(HttpMethod.GET, "/")
 		;
 	}

--- a/server/wfnews-service-api/pom.xml
+++ b/server/wfnews-service-api/pom.xml
@@ -198,6 +198,11 @@
 		<version>2.12.1</version>
 	</dependency>
 
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sns</artifactId>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<!-- Configure the resources to be filtered for property replacement -->

--- a/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/EmailNotificationService.java
+++ b/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/EmailNotificationService.java
@@ -1,15 +1,14 @@
 package ca.bc.gov.nrs.wfnews.service.api.v1;
 
 import javax.mail.MessagingException;
+
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
+
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 public interface EmailNotificationService {
-
     public void sendErrorMessage(String message, Exception e) throws UnsupportedEncodingException, MessagingException;
-
-//    public void sendErrorMessage(List<String> messages, Exception e) throws MessagingException, UnsupportedEncodingException;
-    
     public void sendErrorMessage(String message, Exception e, boolean overrideFrequencyLimit) throws UnsupportedEncodingException, MessagingException;
-
+    public boolean sendMessage(MailResource mail);
 }

--- a/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/impl/EmailNotificationServiceImpl.java
+++ b/server/wfnews-service-api/src/main/java/ca/bc/gov/nrs/wfnews/service/api/v1/impl/EmailNotificationServiceImpl.java
@@ -1,11 +1,9 @@
 package ca.bc.gov.nrs.wfnews.service.api.v1.impl;
 
-import ca.bc.gov.nrs.wfnews.service.api.v1.EmailNotificationService;
-import ca.bc.gov.nrs.wfnews.service.api.v1.config.EmailNotificationConfig;
-import ca.bc.gov.nrs.wfnews.service.api.model.EmailNotificationType;
-import com.sun.org.apache.xpath.internal.operations.Bool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -13,12 +11,23 @@ import javax.mail.Transport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import java.io.UnsupportedEncodingException;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+
+import ca.bc.gov.nrs.wfnews.api.rest.v1.resource.MailResource;
+import ca.bc.gov.nrs.wfnews.service.api.model.EmailNotificationType;
+import ca.bc.gov.nrs.wfnews.service.api.v1.EmailNotificationService;
+import ca.bc.gov.nrs.wfnews.service.api.v1.config.EmailNotificationConfig;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import software.amazon.awssdk.services.sns.model.SnsException;
 
 public class EmailNotificationServiceImpl implements EmailNotificationService {
 
@@ -28,7 +37,16 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
 	private Session emailSession;
 	private InternetAddress[] toAddresses;
 	private Instant lastGeneralEmailSent;
-	private Map errorExceptionMap = new HashMap<String, Instant>();
+	private Map<String, Instant> errorExceptionMap = new HashMap<>();
+	// AWS
+	private SnsClient snsClient;
+
+	@Value("${WFNEWS_SNS_TOPIC_ARN}")
+	private String topicArn;
+	@Value("${WFNEWS_SNS_ACCESS_KEY}")
+	private String accessKey;
+	@Value("${WFNEWS_SNS_SECRET}")
+	private String secret;
 
 	public EmailNotificationServiceImpl(EmailNotificationConfig emailConfig, Session emailSession) {
 		logger.debug("<EmailNotificationServiceImpl");
@@ -36,6 +54,10 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
 		this.emailSession = emailSession;
 		this.init();
 		logger.info("EmailNotificationServiceEnabledInd: {}", emailConfig.getEmailNotificationsEnabledInd());
+		
+		logger.debug("Configure SNS Client");
+		AwsBasicCredentials creds = AwsBasicCredentials.create(accessKey, secret);
+		this.snsClient = SnsClient.builder().region(Region.CA_CENTRAL_1).credentialsProvider(StaticCredentialsProvider.create(creds)).build();
 		logger.debug("EmailNotificationServiceImpl>");
 	}
 
@@ -196,4 +218,30 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
 
 	}
 
+	public boolean sendMessage(MailResource mail) {
+		logger.debug(" >> sendMessage");
+		try {
+			Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
+			messageAttributes.put("name", MessageAttributeValue.builder().stringValue(mail.getName()).dataType("String").build());
+			messageAttributes.put("subject", MessageAttributeValue.builder().stringValue(mail.getSubject()).dataType("String").build());
+			messageAttributes.put("address", MessageAttributeValue.builder().stringValue(mail.getEmailAddress()).dataType("String").build());
+			messageAttributes.put("message", MessageAttributeValue.builder().stringValue(mail.getMessageBody()).dataType("String").build());
+
+			PublishRequest request = PublishRequest.builder().message("Request for Information. Details available in attribution.").messageAttributes(messageAttributes).topicArn(topicArn).build();
+			PublishResponse result = snsClient.publish(request);
+			if (result != null && result.messageId() != null) {
+				logger.info("SNS Message response ID: {}", result.messageId());
+				logger.info("SNS Message Status: {}", result.sdkHttpResponse().statusCode());
+				return result.sdkHttpResponse().statusCode() == 200;
+			} else {
+				return false;
+			}
+		} catch (SnsException e) {
+				System.err.println(e.awsErrorDetails().errorMessage());
+				logger.error("Failed to send message to SNS: " + e.awsErrorDetails().errorMessage(), e);
+				return false;
+		} finally {
+			logger.debug(" << sendMessage");
+		}
+	}
 }


### PR DESCRIPTION
Initial SNS implementation for the message service.

@vivid-cpreston I've added vars for the required AWS topic arn and secrets. These will need to be added to our build chain vars:

```
WFNEWS_SNS_TOPIC_ARN
WFNEWS_SNS_ACCESS_KEY
WFNEWS_SNS_SECRET
```