### PR TITLE
WFNEWS-837: Disable map save with no title, WFNEWS-820

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/admin-incident-form.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/admin-incident-form.component.scss
@@ -15,7 +15,8 @@
   color: #355992;
   font-size: 0.9rem;
   font-weight: 600;
-  text-decoration: none; 
+  text-decoration: none;
+  width: 155px;
 }
 
 .top {

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/edit-map-dialog/edit-map-dialog.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/edit-map-dialog/edit-map-dialog.component.html
@@ -7,7 +7,7 @@
     </mat-form-field>
   </div>
   <div class="dialog-actions" mat-dialog-actions>
-  	<button mat-raised-button color="primary" [mat-dialog-close]="true">Save</button>
+  	<button mat-raised-button color="primary" [mat-dialog-close]="true" [disabled]="data.attachment.attachmentTitle === null || data.attachment.attachmentTitle === ''">Save</button>
 	  <button mat-raised-button [mat-dialog-close]="false">Cancel</button>
   </div>
 </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/upload-map-dialog/upload-map-dialog.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/upload-map-dialog/upload-map-dialog.component.html
@@ -9,7 +9,7 @@
     </mat-form-field>
   </div>
   <div class="dialog-actions" mat-dialog-actions>
-  	<button mat-raised-button color="primary" [mat-dialog-close]="returnResult()" (disabled)="file === null">Save</button>
+  	<button mat-raised-button color="primary" [mat-dialog-close]="returnResult()" [disabled]="file === null || title === null || title === ''">Save</button>
 	  <button mat-raised-button [mat-dialog-close]="false">Cancel</button>
   </div>
 </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/summary-panel/summary-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/summary-panel/summary-panel.component.html
@@ -14,6 +14,10 @@
           <div class="label">Stage of Control</div>
           <div><strong>{{incident.incidentData ? convertToStageOfControlDescription(incident.incidentData.incidentSituation.stageOfControlCode) : ''}}</strong></div>
         </div>
+        <div class="field size-quarter">
+          <div class="label">Response Type</div>
+          <div><strong style="text-transform: capitalize;">{{incident.incidentData ? incident.incidentData.responseTypeCode.toLowerCase() : ''}}</strong></div>
+        </div>
       </div>
     </fieldset>
   </mat-card>


### PR DESCRIPTION
Disabled save button on map dialog, also small fix to the back to dashboard link for WFNEWS-820