### PR TITLE
WFNEWS-853: Add null check to highlightLayer

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/panel-wildfire-stage-of-control/panel-wildfire-stage-of-control.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/panel-wildfire-stage-of-control/panel-wildfire-stage-of-control.component.ts
@@ -72,7 +72,9 @@ export class PanelWildfireStageOfControlComponent extends CollectionComponent im
     const SMK = window['SMK'];
     for (const smkMap in SMK.MAP) {
       if (Object.prototype.hasOwnProperty.call(SMK.MAP, smkMap)) {
-        SMK.MAP[smkMap].$viewer.map.removeLayer(this.highlightLayer);
+        if (this.highlightLayer && this.highlightLayer._leaflet_id) {
+          SMK.MAP[smkMap].$viewer.map.removeLayer(this.highlightLayer);
+        }
       }
     }
 


### PR DESCRIPTION
Null check missing on highlight layer which could cause errors when disconnecting the map and the panel. Null check added