### PR TITLE
WFNEWS-838:  Correct evac order and area restriction display on preview

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
@@ -144,7 +144,7 @@ export class PublicIncidentPage implements OnInit {
   }
 
   async getAreaRestrictions () {
-    return this.agolService.getAreaRestrictions(this.incident.geometry, { returnCentroid: true, returnGeometry: false}).toPromise().then(response => {
+    return this.agolService.getAreaRestrictions({ x: this.incident.longitude, y: this.incident.latitude}).toPromise().then(response => {
       if (response.features) {
         for (const element of response.features) {
           this.areaRestrictions.push({
@@ -153,8 +153,7 @@ export class PublicIncidentPage implements OnInit {
             accessStatusEffectiveDate: element.attributes.ACCESS_STATUS_EFFECTIVE_DATE,
             fireCentre: element.attributes.FIRE_CENTRE_NAME,
             fireZone: element.attributes.FIRE_ZONE_NAME,
-            bulletinUrl: element.attributes.BULLETIN_URL,
-            centroid: element.centroid
+            bulletinUrl: element.attributes.BULLETIN_URL
           })
         }
       }

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
@@ -71,16 +71,26 @@ export class PublicIncidentPage implements OnInit {
         })
       } else {
         if(params && params['preview']) {
-          this.incident = JSON.parse(localStorage.getItem("preview_incident"));
-          // activate page
-          this.isLoading = false
-          this.cdr.detectChanges()
+          this.loadPreview()
         } else {
           this.isLoading = false
           this.loadingFailed = true
         }
       }
     })
+  }
+
+  async loadPreview () {
+    this.incident = JSON.parse(localStorage.getItem("preview_incident"))
+    // fetch the fire perimetre
+    await this.getFirePerimetre()
+    // load evac orders and area restrictions nearby
+    await this.getEvacOrders()
+    await this.getExternalUriEvacOrders()
+    await this.getAreaRestrictions()
+    // activate page
+    this.isLoading = false
+    this.cdr.detectChanges()
   }
 
   async getFirePerimetre () {

--- a/client/wfnews-war/src/main/angular/src/app/interceptors/wfnews-interceptor.ts
+++ b/client/wfnews-war/src/main/angular/src/app/interceptors/wfnews-interceptor.ts
@@ -28,14 +28,12 @@ export class WfnewsInterceptor extends AuthenticationInterceptor implements Http
         requestId = `WFNEWSUI${UUID.UUID().toUpperCase()}`.replace(/-/g, "");
 
         if (this.isUrlSecured(req.url)) {
-          console.log('secure request ' + req.url)
             if (!this.tokenService) {
                 this.tokenService = this.injector.get(TokenService);
             }
             return this.handleLogin(req, next, this.tokenService, requestId);
 
         } else {
-          console.log('un-secure request ' + req.url)
             return this.handleRequest(requestId, next, processedRequest);
         }
     }

--- a/client/wfnews-war/src/main/angular/src/app/services/AGOL-service.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/AGOL-service.ts
@@ -17,6 +17,9 @@ export class AGOLService {
 
   getFirePerimetre (fireNumber: string, options: AgolOptions = null) {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLperimetres'].toString()
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
     // append query. Only search for Fire events
     url += `query?where=FIRE_NUMBER='${fireNumber}'&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
 
@@ -28,6 +31,9 @@ export class AGOLService {
 
   getEvacOrdersByEventNumber (eventNumber: string, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLevacOrders'].toString()
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
     // append query. Only search for Fire events
     url += `query?where=EVENT_NUMBER='${eventNumber}'&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
 
@@ -39,6 +45,9 @@ export class AGOLService {
 
   getEvacOrders (location: { x: number, y: number} | null = null, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLevacOrders'].toString()
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
     // append query. Only search for Fire events
     url += `query?where=EVENT_TYPE='fire'&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
 
@@ -56,7 +65,9 @@ export class AGOLService {
 
   getAreaRestrictionsByID (sysId: string, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLareaRestrictions'].toString();
-
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
     // append query
     url += `query?where=PROT_RA_SYSID=${sysId}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
 
@@ -68,6 +79,10 @@ export class AGOLService {
 
   getAreaRestrictions (location: { x: number, y: number} | null = null, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLareaRestrictions'].toString();
+
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
 
     // append query
     url += `query?where=1=1&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
@@ -87,6 +102,10 @@ export class AGOLService {
   getBansAndProhibitionsById (sysId: string, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLBansAndProhibitions'].toString();
 
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
+
     // append query
     url += `query?where=PROT_BAP_SYSID=${sysId}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`
 
@@ -98,6 +117,10 @@ export class AGOLService {
 
   getBansAndProhibitions (location: { x: number, y: number} | null = null, options: AgolOptions = null): Observable<any> {
     let url = this.appConfigService.getConfig().externalAppConfig['AGOLBansAndProhibitions'].toString();
+
+    if (!url.endsWith('/')) {
+      url += '/'
+    }
 
     // append query
     url += `query?where=1=1&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&units=esriSRUnit_Meter&outFields=*&returnGeometry=${options && options.returnGeometry ? true : false}&returnCentroid=${options && options.returnCentroid ? true : false}&returnExtentOnly=${options && options.returnExtent ? true : false}&featureEncoding=esriDefault&outSR=4326&defaultSR=4326&returnIdsOnly=false&returnQueryGeometry=false&cacheHint=false&returnExceededLimitFeatures=true&sqlFormat=none&f=pjson&token=`


### PR DESCRIPTION
Updated the preview mode to allow the evacs and restrictions to display
Also made a fix that ensures the correct area restrictions are queried, caused by potentially null geometry returning the whole province in the query