### PR TITLE
wfnews 896 map tab wording change. warning text style change

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-gallery-panel/incident-gallery-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-gallery-panel/incident-gallery-panel.component.html
@@ -4,50 +4,52 @@
           <div *ngIf="showImageWarning" class="preview-warning">Warning: Uploaded Images or Videos cannot be previewed</div>
       </h4>
     </div>
-    <div class="content-panel" *ngIf="videos && videos.length || images && images.length; else showDisclaimer" >
-        <div class="media-types">
-            <div>Media Type</div>
-            <mat-select appWFSingleSelect appWFPlaceholder="Select..."
-                        aria-label="Type" [options]="mediaTypeOptions"
-                        [value]="currentMediaType"
-                        (valueChange)="onMediaTypeFilterChanged($event)"
-                        style="border: 1px solid;border-radius: 4px;width: 10%;border-color: gray;padding-left: 10px; margin: 10px 0 10px 0;">
-                <mat-option value="">
-                    <span class="placeholder">Select...</span>
-                </mat-option>
-                <mat-option *ngFor = "let mediaType of mediaTypeOptions" value="{{mediaType}}">
-                    <span>{{mediaType}}</span>
-                </mat-option>
-            </mat-select>
-        </div>
-        <div>
-          <lightgallery *ngIf="showImages" [settings]="settings" [onBeforeSlide]="onBeforeSlide" [onInit]="onInit" class="gallery-container">
-            <a *ngFor="let item of images; let i = index"
-                [attr.data-index]="i"
-                data-lg-size="480-475-480, 800-791-800, 1406-1390"
-                class="gallery-item"
-                [href]="item.href"
-                [data-src]="item.href"
-                [data-responsive]="item.href + ' 800'"
-                style="padding: 5px;">
-                <img [id]="i + '-img-thumb'" width="150" alt="Image" class="img-responsive" [src]="item.thumbnail" (error)="handleImageFallback(item, i)"/>
-            </a>
-          </lightgallery>
+    <div class="content-panel">
+      <div *ngIf="videos && videos.length || images && images.length; else showDisclaimer">
+          <div class="media-types">
+              <div>Media Type</div>
+              <mat-select appWFSingleSelect appWFPlaceholder="Select..."
+                          aria-label="Type" [options]="mediaTypeOptions"
+                          [value]="currentMediaType"
+                          (valueChange)="onMediaTypeFilterChanged($event)"
+                          style="border: 1px solid;border-radius: 4px;width: 10%;border-color: gray;padding-left: 10px; margin: 10px 0 10px 0;">
+                  <mat-option value="">
+                      <span class="placeholder">Select...</span>
+                  </mat-option>
+                  <mat-option *ngFor = "let mediaType of mediaTypeOptions" value="{{mediaType}}">
+                      <span>{{mediaType}}</span>
+                  </mat-option>
+              </mat-select>
+          </div>
+          <div>
+            <lightgallery *ngIf="showImages" [settings]="settings" [onBeforeSlide]="onBeforeSlide" [onInit]="onInit" class="gallery-container">
+              <a *ngFor="let item of images; let i = index"
+                  [attr.data-index]="i"
+                  data-lg-size="480-475-480, 800-791-800, 1406-1390"
+                  class="gallery-item"
+                  [href]="item.href"
+                  [data-src]="item.href"
+                  [data-responsive]="item.href + ' 800'"
+                  style="padding: 5px;">
+                  <img [id]="i + '-img-thumb'" width="150" alt="Image" class="img-responsive" [src]="item.thumbnail" (error)="handleImageFallback(item, i)"/>
+              </a>
+            </lightgallery>
 
-          <div *ngIf="showVideos">
-              <youtube-player *ngFor="let item of videos"
-                  style="padding: 5px;"
-                  videoId={{convertToYoutubeId(item.href)}}
-                  suggestedQuality="highres"
-                  [startSeconds]="1"
-                  [endSeconds]="20"
-                  [height]="250"
-                  [width]="400">
-              </youtube-player>
+            <div *ngIf="showVideos">
+                <youtube-player *ngFor="let item of videos"
+                    style="padding: 5px;"
+                    videoId={{convertToYoutubeId(item.href)}}
+                    suggestedQuality="highres"
+                    [startSeconds]="1"
+                    [endSeconds]="20"
+                    [height]="250"
+                    [width]="400">
+                </youtube-player>
+            </div>
           </div>
         </div>
-      </div>
       <ng-template #showDisclaimer>
-        <p *ngIf="!isPreview">There are currently no images or videos associated with this incident</p>
+        <div *ngIf="!isPreview">There are currently no images or videos associated with this incident</div>
       </ng-template>
+    </div>
 </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-gallery-panel/incident-gallery-panel.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-gallery-panel/incident-gallery-panel.component.scss
@@ -50,7 +50,7 @@
       font-weight: 700;
     }
     .content-panel {
-      padding-top: 10px;
+      padding-top: 30px;
       border-bottom: 1px lightgray solid;
       .media-types {
         padding-top:15px;

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-maps-panel/incident-maps-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-maps-panel/incident-maps-panel.component.html
@@ -1,7 +1,7 @@
 <div class="panel">
     <div class="header-row">
       <h4>Wildfire Maps
-        <div *ngIf="showMapsWarning" class="preview-warning">Warning: Uploaded Images or Videos cannot be previewed</div>
+        <div *ngIf="showMapsWarning" class="preview-warning">Warning: Uploaded Maps cannot be previewed</div>
       </h4>
     </div>
     <div class="content-panel">

--- a/client/wfnews-war/src/main/angular/src/styles/main.scss
+++ b/client/wfnews-war/src/main/angular/src/styles/main.scss
@@ -630,4 +630,5 @@ wf-admin-incident-desktop{
 .preview-warning {
   font-size: 10px;
   color:red;
+  font-weight: 400;
 }


### PR DESCRIPTION
tac comment: 
_Sorry I just realized that I did not update the warning text under the Wildfires maps tab when previewing.   It should say "Warning: Uploaded Maps cannot be previewed"   I must have just pasted in the other text and forgot to update it.  I think as well it should match the same styling as the "Warning: Manually entered Evacuation Orders and Alerts cannot be previewed" warning which is not bolded.  Same goes for the image gallery warning (should not be bolded).

Also the two should match with regards to a horizontal line under the warning.  Either it should exist on both or should not exist at all._

