### PR TITLE
WFNEWS-1114: Handle AWS exception

### DIFF
--- a/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/AttachmentsEndpointImpl.java
+++ b/server/wfnews-api-rest-endpoints/src/main/java/ca/bc/gov/nrs/wfnews/api/rest/v1/endpoints/impl/AttachmentsEndpointImpl.java
@@ -260,7 +260,7 @@ public class AttachmentsEndpointImpl extends BaseEndpointsImpl implements Attach
 			} else {
 				response = Response.status(404).build();
 			}
-		} catch (NoSuchKeyException e) {
+		} catch (AwsServiceException | SdkClientException e) {
 			response = Response.status(404).build();
 		} catch (IOException e) {
 			response = getInternalServerErrorResponse(e);


### PR DESCRIPTION
Catch AWS exception and return default 404, not AWS 403 messages