### PR TITLE
Move evac to AGO layer

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/bc-fire-centres.config.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/bc-fire-centres.config.ts
@@ -3,13 +3,13 @@ import { layerSettings } from '.';
 export function FireCentresLayerConfig(ls: layerSettings) {
   return [
     {
-          type: 'esri-tiled',
-          id: 'bc-fire-centres',
-          title: 'BC Wildfire Fire Centres',
-          isQueryable: false,
-          attribution: 'Copyright 117 DataBC, Government of British Columbia',
-          serviceUrl: 'https://tiles.arcgis.com/tiles/ubm4tcTYICKBpist/arcgis/rest/services/BCWS_FireCenterBdys2/MapServer',
-          opacity: 1
+      type: 'esri-tiled',
+      id: 'bc-fire-centres',
+      title: 'BC Wildfire Fire Centres',
+      isQueryable: false,
+      attribution: 'Copyright 117 DataBC, Government of British Columbia',
+      serviceUrl: 'https://tiles.arcgis.com/tiles/ubm4tcTYICKBpist/arcgis/rest/services/BCWS_FireCenterBdys2/MapServer',
+      opacity: 1
     },
     /*{
       type: 'wms',

--- a/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/evacuation-orders-and-alerts-wms.config.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/evacuation-orders-and-alerts-wms.config.ts
@@ -3,6 +3,46 @@ import { layerSettings } from '.';
 export function EvacuationOrdersLayerConfig(ls: layerSettings) {
   return [
     {
+      type: 'esri-feature',
+      id: 'evacuation-orders-and-alerts-wms',
+      title: 'Evacuation Orders and Alerts',
+      attribution: 'Copyright 117 DataBC, Government of British Columbia',
+      serviceUrl: ls.evacOrdersURL,
+      where: 'ORDER_ALERT_STATUS <> \'All Clear\' and (EVENT_TYPE = \'Fire\' or EVENT_TYPE = \'Wildfire\')',
+      opacity: 0.65,
+      titleAttribute: 'EVENT_NAME',
+      popupTemplate:
+        '<div class="smk-popup"><div class="popup-header"><mat-icon role="img" class="mat-icon notranslate material-icons mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font">error</mat-icon><span class="title-label">Evacuation Orders and Alerts</span></div><div class="popup-title">{{feature.properties["EVENT_NAME"]}}</div><div class="popup-attributes"><div class="label">Date Active:</div><div class="attribute">{{new Date(feature.properties["DATE_MODIFIED"]).toISOString().slice(0, 10)}}</div></div><div class="popup-attributes"><div class="label">Agency:</div><div class="attribute">{{feature.properties["ISSUING_AGENCY"]}}</div></div><div class="popup-attributes"><div class="label">Status:</div><div class="attribute attribute-red">{{feature.properties["ORDER_ALERT_STATUS"]}}</div></div><div class="popup-button-container"><a class="popup-button" target="_blank" rel="noopener" v-if="feature.properties[\'BULLETIN_URL\']" v-bind:href="feature.properties[\'BULLETIN_URL\']">Learn More</a></div></div>',
+      geometryAttribute: 'SHAPE',
+      attributes: [
+        {
+          name: 'EVENT_NAME',
+          title: 'Name',
+        },
+        {
+          name: 'EVENT_TYPE',
+          title: 'Type',
+        },
+        {
+          name: 'DATE_MODIFIED',
+          title: 'Date',
+        },
+        {
+          name: 'ISSUING_AGENCY',
+          title: 'Issuing Agency',
+        },
+        {
+          name: 'ORDER_ALERT_STATUS',
+          title: 'Status',
+        },
+      ],
+      legend: {
+        clipHeight: 60,
+      }
+    }
+    // temporary swap to AGO due to performance concerns from DataBC
+    // will swap back once we have the cache set up for this layer
+    /*{
       type: 'wms',
       id: 'evacuation-orders-and-alerts-wms',
       title: 'Evacuation Orders and Alerts',
@@ -11,7 +51,7 @@ export function EvacuationOrdersLayerConfig(ls: layerSettings) {
         'pub:WHSE_HUMAN_CULTURAL_ECONOMIC.EMRG_ORDER_AND_ALERT_AREAS_SP',
       styleName: '6885',
       isQueryable: true,
-      where: 'ORDER_ALERT_STATUS <> \'All Clear\' and EVENT_TYPE = \'Fire\'',
+      where: 'ORDER_ALERT_STATUS <> \'All Clear\' and (EVENT_TYPE = \'Fire\' or EVENT_TYPE = \'Wildfire\')',
       opacity: 0.65,
       titleAttribute: 'EVENT_NAME',
       popupTemplate:
@@ -52,6 +92,6 @@ export function EvacuationOrdersLayerConfig(ls: layerSettings) {
         'pub:WHSE_HUMAN_CULTURAL_ECONOMIC.EMRG_ORDER_AND_ALERT_AREAS_SP',
       opacity: 0.8,
       sld: `@${window.location.protocol}//${window.location.host}/assets/js/smk/evacuation-orders-and-alerts-wms-highlight.sld`,
-    },
+    },*/
   ];
 }

--- a/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/index.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/map-config.service/layers/index.ts
@@ -29,6 +29,7 @@ export interface layerSettings {
   openmapsBaseUrl: string;
   drivebcBaseUrl: string;
   wfnewsUrl: string;
+  evacOrdersURL: string;
 }
 export function LayerConfig(
   mapServices: MapServices,
@@ -39,6 +40,7 @@ export function LayerConfig(
     openmapsBaseUrl: mapServices['openmapsBaseUrl'],
     drivebcBaseUrl: mapServices['drivebcBaseUrl'],
     wfnewsUrl: mapServices['wfnews'],
+    evacOrdersURL: appConfigService.getConfig().externalAppConfig['AGOLevacOrders'].toString()
   };
 
   return [


### PR DESCRIPTION
Performance concerns with evac orders WMS layer, so moving to AGO until cloudfront cache will be available.