### PR TITLE
Set current incident number label in admin screen

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/admin-incident-form.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/admin-incident-form.component.ts
@@ -239,6 +239,8 @@ export class AdminIncidentForm implements OnInit, OnChanges {
               self.currentAdminIncident.incidentLocation.latitude;
             self.incident.fireNumber =
               self.currentAdminIncident.incidentNumberSequence;
+            self.incident.incidentLabel =
+                self.currentAdminIncident.incidentLabel;
             self.incident.wildfireYear =
               self.currentAdminIncident.wildfireYear;
             self.incident.fireOfNote =


### PR DESCRIPTION
Missed line from WFNEWS-2164 merge, which is causing the resource fetch from RM to have an incidentNumber of null and therefore return incorrect results.