### PR TITLE
Remove redundant padding

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/incident-tabs.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/incident-tabs.component.scss
@@ -58,7 +58,6 @@
 }
 
 .tab-group{
-  padding: 0 170px;
   background-color: white;
   border-top: 1.5px solid #DDD;
   align-items: center;


### PR DESCRIPTION
This padding is redundant because the contents self center. Removing it fixes a broken edge case and could allow for reuse in the future.

Before
![image](https://github.com/bcgov/nr-bcws-wfnews/assets/6563909/60f1fbda-9849-460a-8f60-fcf1cd60b1c5)


After
![image](https://github.com/bcgov/nr-bcws-wfnews/assets/6563909/1952b98c-5722-4a46-b9ff-69f88ffda216)
