### PR TITLE
Response update card keep shaking when there is only one line of text

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
@@ -19,7 +19,7 @@ export class ResponseUpdateCardComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     const size = this.contentElementRef?.nativeElement?.offsetHeight;
-    this.useColumns = size >= (this.columnTrigger * this.columnSize);
+    this.useColumns = size > (this.columnTrigger * this.columnSize);
     if (this.useColumns) {
       this.cdr.detectChanges();
     }

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
@@ -1,11 +1,11 @@
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
+import {AfterContentChecked, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'response-update-card',
   templateUrl: './response-update-card.component.html',
   styleUrls: ['./response-update-card.component.scss']
 })
-export class ResponseUpdateCardComponent implements AfterViewInit {
+export class ResponseUpdateCardComponent implements AfterContentChecked {
   @Input() updateDate?: string;
 
   @ViewChild('responseUpdateContent') contentElementRef: ElementRef;
@@ -14,13 +14,16 @@ export class ResponseUpdateCardComponent implements AfterViewInit {
 
   columnTrigger = 2;
   columnSize = 24;
+  heightThreshold = 200;
+
 
   constructor(private cdr: ChangeDetectorRef) { }
 
-  ngAfterViewInit() {
+  ngAfterContentChecked() {
     const size = this.contentElementRef?.nativeElement?.offsetHeight;
-    this.useColumns = size > (this.columnTrigger * this.columnSize);
-    if (this.useColumns) {
+    const previousUseColumns = this.useColumns;
+    this.useColumns = size > this.heightThreshold;
+    if (this.useColumns !== previousUseColumns ) {
       this.cdr.detectChanges();
     }
   }  

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentChecked, AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'response-update-card',

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/response-update-card/response-update-card.component.ts
@@ -1,11 +1,11 @@
-import { AfterContentChecked, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { AfterContentChecked, AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'response-update-card',
   templateUrl: './response-update-card.component.html',
   styleUrls: ['./response-update-card.component.scss']
 })
-export class ResponseUpdateCardComponent implements AfterContentChecked {
+export class ResponseUpdateCardComponent implements AfterViewInit {
   @Input() updateDate?: string;
 
   @ViewChild('responseUpdateContent') contentElementRef: ElementRef;
@@ -17,9 +17,9 @@ export class ResponseUpdateCardComponent implements AfterContentChecked {
 
   constructor(private cdr: ChangeDetectorRef) { }
 
-  ngAfterContentChecked() {
+  ngAfterViewInit() {
     const size = this.contentElementRef?.nativeElement?.offsetHeight;
-    this.useColumns = size > (this.columnTrigger * this.columnSize);
+    this.useColumns = size >= (this.columnTrigger * this.columnSize);
     if (this.useColumns) {
       this.cdr.detectChanges();
     }


### PR DESCRIPTION
Using AfterContentChecked can indeed lead to performance issues if it is triggered frequently, as it is called after every change detection cycle. This also means this.cdr.detectChanges() gets called too frequently.

Paul Pilon
  3:04 PM
[@Lucas Li](https://vividsolutionsinc.slack.com/team/U01D5LHR0DR)
 If you try to access response section this page, does it look jittery?  Esu noticed that, and I see the same thing on my computer.  Seems to only be ones that only have one line of response update while everything else is default.
https://wfnews-client.test.bcwildfireservices.com/incidents?fireYear=2023&incidentNumber=V65581&source=list