### PR TITLE
Show incidentCauseDetail on desktop public side if it exists

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-panel/incident-info-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-panel/incident-info-panel.component.html
@@ -11,7 +11,7 @@
     <ng-container column-2>
       <primary-media-card *ngIf="primaryMedia" [showPreviewWarning]="showWarning" [item]="primaryMedia" (imageError)="handleImageFallback(primaryMedia.href)" (openAllPhotosClicked)="sendToGalleryTab()" ></primary-media-card>
       <area-restrictions-card [showPreviewWarning]="showWarning" [areaRestrictions]="areaRestrictions" (viewDetailsClicked)="navigateToAreaRestriction($event)" ></area-restrictions-card>
-      <suspected-cause-card [incidentSuspectedCauseCatId]="incident.generalIncidentCauseCatId"></suspected-cause-card>
+      <suspected-cause-card [incident]="incident"></suspected-cause-card>
       <contact-us-card [incident]="incident"></contact-us-card>
     </ng-container>
   </two-column-content-cards-container>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.html
@@ -7,7 +7,7 @@
       <div class="content-title"><img class="icon" [src]="getCauseIcon()" alt="authorities">
         {{ getCauseLabel() }}</div>
       <div class="content-list">
-        <span class="content-text">{{ getCauseDescription() }}</span>
+        <span class="content-text">{{ incident.incidentCauseDetail ? incident.incidentCauseDetail: getCauseDescription() }}</span>
       </div>
     </div>
   </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.html
@@ -7,7 +7,7 @@
       <div class="content-title"><img class="icon" [src]="getCauseIcon()" alt="authorities">
         {{ getCauseLabel() }}</div>
       <div class="content-list">
-        <span class="content-text">{{ incident.incidentCauseDetail ? incident.incidentCauseDetail: getCauseDescription() }}</span>
+        <span class="content-text">{{ getCauseDescription() }}</span>
       </div>
     </div>
   </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
@@ -45,6 +45,9 @@ export class SuspectedCauseCardComponent implements OnInit {
   };
 
   getCauseDescription = () => {
+    if (this.incident?.incidentCauseDetail)
+      return this.incident?.incidentCauseDetail;
+
     switch (this.incidentSuspectedCauseCatId) {
       case 1:
         return CauseOptionDisclaimer[1];

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { CauseOptionDisclaimer } from '@app/components/admin-incident-form/incident-details-panel/incident-details-panel.constants';
 
 @Component({
@@ -6,9 +6,16 @@ import { CauseOptionDisclaimer } from '@app/components/admin-incident-form/incid
   templateUrl: './suspected-cause-card.component.html',
   styleUrls: ['./suspected-cause-card.component.scss']
 })
-export class SuspectedCauseCardComponent {
+export class SuspectedCauseCardComponent implements OnInit {
 
-  @Input() incidentSuspectedCauseCatId: number;
+  @Input() incident: any;
+  public incidentSuspectedCauseCatId: number;
+
+  ngOnInit(): void {
+    if(this.incident?.generalIncidentCauseCatId) {
+      this.incidentSuspectedCauseCatId = this.incident?.generalIncidentCauseCatId;
+    }
+  }
   
   getCauseIcon = () => {
     const directory = 'assets/images/svg-icons/';

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-tabs/cards/suspected-cause-card/suspected-cause-card.component.ts
@@ -13,7 +13,7 @@ export class SuspectedCauseCardComponent implements OnInit {
 
   ngOnInit(): void {
     if(this.incident?.generalIncidentCauseCatId) {
-      this.incidentSuspectedCauseCatId = this.incident?.generalIncidentCauseCatId;
+      this.incidentSuspectedCauseCatId = this.incident.generalIncidentCauseCatId;
     }
   }
   


### PR DESCRIPTION
and show default disclaimer if it is null. I think this functionality was removed when the bug for defaults was fixed. It works on the mobile version already.