### PR TITLE
Fix fire bans links for mobile

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/full-details/danger-rating-full-details/danger-rating-full-details.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/full-details/danger-rating-full-details/danger-rating-full-details.component.scss
@@ -1,12 +1,17 @@
 @import "../full-details.component.scss";
 
 .link-icon {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    height: 20px;
-    width: 20px;
-  }
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  margin-right: 24px;
+}
+
+.links-relative {
+  position: relative;
+  cursor: pointer;
+  padding: 0px 24px;
+}

--- a/client/wfnews-war/src/main/angular/src/assets/data/appConfig.mobile.json
+++ b/client/wfnews-war/src/main/angular/src/assets/data/appConfig.mobile.json
@@ -57,8 +57,8 @@
         "emergencyAlertUrl": "#{EMERGENCY_ALERT_URL}#",
         "driveBCUrl": "#{DRIVE_BC_URL}#",
         "evacServicesUrl": "#{EVAC_SERVICES_URL}#",
-        "dangerSummary": "#{DANGER_SUMMARY}",
-        "highRiskActivities": "#{HIGH_RISK_ACTIVITIES}"
+        "dangerSummary": "#{DANGER_SUMMARY}#",
+        "highRiskActivities": "#{HIGH_RISK_ACTIVITIES}#"
        
     },
 


### PR DESCRIPTION
Fixing side margins for links, they currently have no side margin and are flush to the side of the page:
![image](https://github.com/user-attachments/assets/f1182828-7b8c-45f3-a919-f49ccf3cd733)
Fixing incorrect config for mobile also.