### PR TITLE
wfmews-2425. handle url share between mobile and desktop 

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/app.routing.ts
+++ b/client/wfnews-war/src/main/angular/src/app/app.routing.ts
@@ -22,10 +22,10 @@ import { AddSavedLocationComponent } from '@app/components/saved/add-saved-locat
 import { SavedLocationFullDetailsComponent } from './components/saved/saved-location-full-details/saved-location-full-details.component';
 import { SavedLocationWeatherDetailsComponent } from './components/saved/saved-location-weather-details/saved-location-weather-details.component';
 import { PublicEventPageComponent } from '@app/components/public-event-page/public-event-page.component';
+import { DeviceRedirectGuard } from '@app/services/device-redirect-guard';
 // Components
 
 const PROFILE_SCOPES = [[ROLES_UI.ADMIN, ROLES_UI.IM_ADMIN]];
-
 const PANEL_ROUTES: Routes = [
   // { path: '', component: ActionsPanelComponent, pathMatch: 'full', canActivate: [AuthGuard] },
   {
@@ -80,6 +80,7 @@ const PANEL_ROUTES: Routes = [
     path: ResourcesRoutes.PUBLIC_EVENT,
     component: PublicEventPageComponent,
     pathMatch: 'full',
+    canActivate: [DeviceRedirectGuard],  // Apply the guard
   },
   {
     path: ResourcesRoutes.SIGN_OUT,
@@ -95,6 +96,7 @@ const PANEL_ROUTES: Routes = [
     path: ResourcesRoutes.FULL_DETAILS,
     component: FullDetailsComponent,
     pathMatch: 'full',
+    canActivate: [DeviceRedirectGuard],  // Apply the guard
   },
   {
     path: ResourcesRoutes.WEATHER_DETAILS,

--- a/client/wfnews-war/src/main/angular/src/app/components/preview-panels/danger-rating-preview/danger-rating-preview.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/preview-panels/danger-rating-preview/danger-rating-preview.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { MapUtilityService } from '@app/components/preview-panels/map-share-service';
+import { LocationData } from '@app/components/wildfires-list-header/filter-by-location/filter-by-location-dialog.component';
 import { AGOLService } from '@app/services/AGOL-service';
 import { CapacitorService } from '@app/services/capacitor-service';
 import { CommonUtilityService } from '@app/services/common-utility.service';
@@ -39,12 +40,14 @@ export class DangerRatingPreviewComponent {
   }
 
   enterFullDetail() {
+    const location = new LocationData();
     const url = this.router.serializeUrl(
       this.router.createUrlTree([ResourcesRoutes.PUBLIC_EVENT], {
         queryParams: {
           eventType: 'danger-rating',
           eventNumber: this.data.PROT_DR_SYSID,
           eventName: this.data.DANGER_RATING_DESC,
+          location: JSON.stringify(location),
           source: [ResourcesRoutes.ACTIVEWILDFIREMAP]
         },
       }),

--- a/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { isMobileView } from '@app/utils';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DeviceRedirectGuard implements CanActivate {
+  public isMobileView = isMobileView;
 
   constructor(private router: Router) {}
 
@@ -13,20 +15,18 @@ export class DeviceRedirectGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    const isMobile = (window.innerWidth < 768 && window.innerHeight < 1024) || (window.innerWidth < 1024 && window.innerHeight < 768);
-
     // Split the URL into path and query string
     const [path, queryString] = state.url.split('?');
     const queryParams = new URLSearchParams(queryString || '');
 
-    if (isMobile && path.includes('events')) {
+    if (isMobileView() && path.includes('events')) {
       // Perform query parameter transformations
       this.transformQueryParams(queryParams);
 
       return this.router.parseUrl(`full-details?${queryParams.toString()}`);
     }
 
-    if (!isMobile && path.includes('full-details')) {
+    if (!isMobileView() && path.includes('full-details')) {
       this.reverseTransformQueryParams(queryParams);
       return this.router.parseUrl(`events?${queryParams.toString()}`);
     }

--- a/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DeviceRedirectGuard implements CanActivate {
+
+  constructor(private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    const isMobile = (window.innerWidth < 768 && window.innerHeight < 1024) || (window.innerWidth < 1024 && window.innerHeight < 768);
+
+    // Split the URL into path and query string
+    const [path, queryString] = state.url.split('?');
+    const queryParams = new URLSearchParams(queryString || '');
+
+    if (isMobile && path.includes('events')) {
+      // Perform query parameter transformations
+      this.transformQueryParams(queryParams);
+
+      return this.router.parseUrl(`full-details?${queryParams.toString()}`);
+    }
+
+    if (!isMobile && path.includes('full-details')) {
+      this.reverseTransformQueryParams(queryParams);
+      return this.router.parseUrl(`events?${queryParams.toString()}`);
+    }
+
+    // If conditions are met, allow the route to activate
+    return true;
+  }
+
+  // Function to handle query parameter transformations
+  private transformQueryParams(queryParams: URLSearchParams): void {
+    const eventType = queryParams.get('eventType');
+    
+    switch (eventType) {
+      case 'Order':
+        queryParams.set('type', 'evac-order'); // Change 'eventType=Order' to 'type=evac-order'
+        break;
+      case 'Alert':
+        queryParams.set('type', 'evac-alert'); // Change 'eventType=Alert' to 'type=evac-alert'
+        break;
+      case 'area-restriction':
+        queryParams.set('type', 'area-restriction'); // Change 'eventType=area-restriction' to 'type=area-restriction'
+        this.renameQueryParams(queryParams, 'eventNumber', 'id');
+        this.renameQueryParams(queryParams, 'eventName', 'name');
+        break;
+      case 'ban':
+        queryParams.set('type', 'bans-prohibitions'); // Change 'eventType=ban' to 'type=bans-prohibitions'
+        this.renameQueryParams(queryParams, 'eventNumber', 'id');
+        break;
+      case 'danger-rating':
+        queryParams.set('type', 'danger-rating'); // Change 'eventType=ban' to 'type=bans-prohibitions'
+        this.renameQueryParams(queryParams, 'eventNumber', 'sysid');
+        this.renameQueryParams(queryParams, 'eventName', 'id');
+        break;
+      default:
+        break;
+    }
+  }
+
+    // Reverse the query parameter transformations (for desktop)
+    private reverseTransformQueryParams(queryParams: URLSearchParams): void {
+      const type = queryParams.get('type');
+      
+      switch (type) {
+        case 'evac-order':
+          queryParams.set('eventType', 'Order'); // Reverse 'type=evac-order' to 'eventType=Order'
+          break;
+        case 'evac-alert':
+          queryParams.set('eventType', 'Alert'); // Reverse 'type=evac-alert' to 'eventType=Alert'
+          break;
+        case 'area-restriction':
+          queryParams.set('eventType', 'area-restriction'); // Reverse 'type=area-restriction' to 'eventType=area-restriction'
+          this.renameQueryParams(queryParams, 'id', 'eventNumber');
+          this.renameQueryParams(queryParams, 'name', 'eventName');
+          break;
+        case 'bans-prohibitions':
+          queryParams.set('eventType', 'ban'); // Reverse 'type=bans-prohibitions' to 'eventType=ban'
+          this.renameQueryParams(queryParams, 'id', 'eventNumber');
+          break;
+        case 'danger-rating':
+          queryParams.set('eventType', 'danger-rating'); // Reverse 'type=danger-rating' to 'eventType=danger-rating'
+          this.renameQueryParams(queryParams, 'sysid', 'eventNumber');
+          this.renameQueryParams(queryParams, 'id', 'eventName');
+          break;
+        default:
+          break;
+      }
+    }
+
+  // Helper function to rename query parameters
+  private renameQueryParams(queryParams: URLSearchParams, oldKey: string, newKey: string): void {
+    const value = queryParams.get(oldKey);
+    if (value) {
+      queryParams.set(newKey, value);
+      queryParams.delete(oldKey);
+    }
+  }
+}

--- a/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/device-redirect-guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { isMobileView } from '@app/utils';
+import { isMobileView,EventTypes, Types } from '@app/utils';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -38,25 +38,25 @@ export class DeviceRedirectGuard implements CanActivate {
   // Function to handle query parameter transformations
   private transformQueryParams(queryParams: URLSearchParams): void {
     const eventType = queryParams.get('eventType');
-    
+
     switch (eventType) {
-      case 'Order':
-        queryParams.set('type', 'evac-order'); // Change 'eventType=Order' to 'type=evac-order'
+      case EventTypes.ORDER:
+        queryParams.set('type', Types.EVAC_ORDER);
         break;
-      case 'Alert':
-        queryParams.set('type', 'evac-alert'); // Change 'eventType=Alert' to 'type=evac-alert'
+      case EventTypes.ALERT:
+        queryParams.set('type', Types.EVAC_ALERT);
         break;
-      case 'area-restriction':
-        queryParams.set('type', 'area-restriction'); // Change 'eventType=area-restriction' to 'type=area-restriction'
+      case EventTypes.AREA_RESTRICTION:
+        queryParams.set('type', Types.AREA_RESTRICTION);
         this.renameQueryParams(queryParams, 'eventNumber', 'id');
         this.renameQueryParams(queryParams, 'eventName', 'name');
         break;
-      case 'ban':
-        queryParams.set('type', 'bans-prohibitions'); // Change 'eventType=ban' to 'type=bans-prohibitions'
+      case EventTypes.BAN:
+        queryParams.set('type', Types.BANS_PROHIBITIONS);
         this.renameQueryParams(queryParams, 'eventNumber', 'id');
         break;
-      case 'danger-rating':
-        queryParams.set('type', 'danger-rating'); // Change 'eventType=ban' to 'type=bans-prohibitions'
+      case EventTypes.DANGER_RATING:
+        queryParams.set('type', Types.DANGER_RATING);
         this.renameQueryParams(queryParams, 'eventNumber', 'sysid');
         this.renameQueryParams(queryParams, 'eventName', 'id');
         break;
@@ -65,35 +65,34 @@ export class DeviceRedirectGuard implements CanActivate {
     }
   }
 
-    // Reverse the query parameter transformations (for desktop)
-    private reverseTransformQueryParams(queryParams: URLSearchParams): void {
-      const type = queryParams.get('type');
-      
-      switch (type) {
-        case 'evac-order':
-          queryParams.set('eventType', 'Order'); // Reverse 'type=evac-order' to 'eventType=Order'
-          break;
-        case 'evac-alert':
-          queryParams.set('eventType', 'Alert'); // Reverse 'type=evac-alert' to 'eventType=Alert'
-          break;
-        case 'area-restriction':
-          queryParams.set('eventType', 'area-restriction'); // Reverse 'type=area-restriction' to 'eventType=area-restriction'
-          this.renameQueryParams(queryParams, 'id', 'eventNumber');
-          this.renameQueryParams(queryParams, 'name', 'eventName');
-          break;
-        case 'bans-prohibitions':
-          queryParams.set('eventType', 'ban'); // Reverse 'type=bans-prohibitions' to 'eventType=ban'
-          this.renameQueryParams(queryParams, 'id', 'eventNumber');
-          break;
-        case 'danger-rating':
-          queryParams.set('eventType', 'danger-rating'); // Reverse 'type=danger-rating' to 'eventType=danger-rating'
-          this.renameQueryParams(queryParams, 'sysid', 'eventNumber');
-          this.renameQueryParams(queryParams, 'id', 'eventName');
-          break;
-        default:
-          break;
-      }
+  private reverseTransformQueryParams(queryParams: URLSearchParams): void {
+    const type = queryParams.get('type');
+
+    switch (type) {
+      case Types.EVAC_ORDER:
+        queryParams.set('eventType', EventTypes.ORDER);
+        break;
+      case Types.EVAC_ALERT:
+        queryParams.set('eventType', EventTypes.ALERT);
+        break;
+      case Types.AREA_RESTRICTION:
+        queryParams.set('eventType', EventTypes.AREA_RESTRICTION);
+        this.renameQueryParams(queryParams, 'id', 'eventNumber');
+        this.renameQueryParams(queryParams, 'name', 'eventName');
+        break;
+      case Types.BANS_PROHIBITIONS:
+        queryParams.set('eventType', EventTypes.BAN);
+        this.renameQueryParams(queryParams, 'id', 'eventNumber');
+        break;
+      case Types.DANGER_RATING:
+        queryParams.set('eventType', EventTypes.DANGER_RATING);
+        this.renameQueryParams(queryParams, 'sysid', 'eventNumber');
+        this.renameQueryParams(queryParams, 'id', 'eventName');
+        break;
+      default:
+        break;
     }
+  }
 
   // Helper function to rename query parameters
   private renameQueryParams(queryParams: URLSearchParams, oldKey: string, newKey: string): void {

--- a/client/wfnews-war/src/main/angular/src/app/utils/index.ts
+++ b/client/wfnews-war/src/main/angular/src/app/utils/index.ts
@@ -266,6 +266,22 @@ export const FireZones = [
   },
 ];
 
+export const EventTypes = {
+  ORDER: 'Order',
+  ALERT: 'Alert',
+  AREA_RESTRICTION: 'area-restriction',
+  BAN: 'ban',
+  DANGER_RATING: 'danger-rating'
+};
+
+export const Types = {
+  EVAC_ORDER: 'evac-order',
+  EVAC_ALERT: 'evac-alert',
+  AREA_RESTRICTION: 'area-restriction',
+  BANS_PROHIBITIONS: 'bans-prohibitions',
+  DANGER_RATING: 'danger-rating'
+};
+
 export function getPageInfoRequestForSearchState(
   searchState: any,
 ): PagingInfoRequest {


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WFNEWS-2425
Add URL query parameter transformation logic for mobile and desktop routes.
Handle query parameter transformations, purpose of these is because or mobile detail page for evac, area-restrictions, bans, dang rating are different as desktop detail page and uses different parameters. Eventually we might want to align them but it way too out of scope of WFNEWS-2425 and WFNEWS-2423

ie: desktop area-restriction detail page is: /events?eventType=area-restriction&eventNumber=2&eventName=C55175%20Area%20Restriction
but mobile area-restriction detail page is :/full-details?type=area-restriction&id=2&source=list&name=C55175%20Area%20Restriction