### PR TITLE
updating sonar scan to watch defaut (2.4.0) branch

### DIFF
--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -5,8 +5,11 @@ env:
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - '2.4.0'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   build:


### PR DESCRIPTION
The sonarscan isn't up to date because it's only set to watch PRs and the 'main' branch. This should set it to also watch our current default branch named '4.2.0'.