### PR TITLE
remove sld for dangerrating as it getting insanly long

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-header/incident-header-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-header/incident-header-panel.component.ts
@@ -410,8 +410,7 @@ export class IncidentHeaderPanelComponent implements AfterViewInit, OnInit {
               opacity: 0.8,
               tileSize: 1000,
               bounds: bounds,
-              style: '7734',
-              sld_body: dangerRating,
+              style: '7734'            
             })
             .addTo(this.map);
         })


### PR DESCRIPTION
The .sld file we have in assets makes the request url overwhelming. Removed it makes the desktop detail map works again.
![image](https://github.com/user-attachments/assets/1bf0bbef-1f2c-4b3e-ac9c-9600e0445bc4)
