### PR TITLE
wfnews-2407

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/utils/index.ts
+++ b/client/wfnews-war/src/main/angular/src/app/utils/index.ts
@@ -598,8 +598,8 @@ export function getStageOfControlIcon(code: string) {
   }
 }
 
-export function convertToDateTimeTimeZone(date) {
-  // e.g. July 19, 2022 at 10:22 a.m. PST
+export function convertToDateTimeTimeZone(date: Date | string): string {
+  // e.g. July 19, 2022 at 10:22 a.m. PST/PDT
   const updateOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -607,11 +607,14 @@ export function convertToDateTimeTimeZone(date) {
     hour: 'numeric',
     minute: 'numeric',
     second: undefined, // this removes the seconds
+    timeZone: 'America/Los_Angeles', // Pacific Time Zone
+    timeZoneName: 'short', // Automatically handles PDT/PST
   };
-  let convertedDate: string;
-  convertedDate = date
-    ? new Date(date).toLocaleTimeString('en-US', updateOptions) + ' PST'
+
+  let convertedDate = date
+    ? new Date(date).toLocaleString('en-US', updateOptions)
     : 'Pending';
+
   if (convertedDate !== 'Pending') {
     // add full stops and lowercase
     convertedDate = convertedDate.replace('AM', 'a.m.');

--- a/client/wfnews-war/src/main/angular/src/app/utils/index.ts
+++ b/client/wfnews-war/src/main/angular/src/app/utils/index.ts
@@ -607,7 +607,6 @@ export function convertToDateTimeTimeZone(date: Date | string): string {
     hour: 'numeric',
     minute: 'numeric',
     second: undefined, // this removes the seconds
-    timeZone: 'America/Los_Angeles', // Pacific Time Zone
     timeZoneName: 'short', // Automatically handles PDT/PST
   };
 


### PR DESCRIPTION
The PDT/PST suffix on a timestamp on the full details page needs to automatically adjust depending on the time of the year
https://apps.nrs.gov.bc.ca/int/jira/browse/WFNEWS-2407
![image](https://github.com/user-attachments/assets/4da3f689-19fb-4572-bf32-499425d458f3)
