### PR TITLE
WFNEWS-2406 Change default Fire Type filtering to All Fire Incidents

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/wf-admin-panel/wf-admin-panel.component.desktop.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/wf-admin-panel/wf-admin-panel.component.desktop.html
@@ -37,10 +37,10 @@
           <div class="fire-type-radio-button-group">
               <mat-label>Fire Type</mat-label>
               <mat-radio-group class="radio-group">
-                  <mat-radio-button class="radio-button" (change)="fireTypeChange($event)" value="note" [checked]="fireOfNotePublishedInd">
+                  <mat-radio-button class="radio-button" (change)="fireTypeChange($event)" value="note">
                       Wildfires Of Note
                   </mat-radio-button>
-                  <mat-radio-button class="radio-button" (change)="fireTypeChange($event)" value="all">
+                  <mat-radio-button class="radio-button" (change)="fireTypeChange($event)" value="all" checked="true">
                       All Fire Incidents
                   </mat-radio-button>
               </mat-radio-group>

--- a/client/wfnews-war/src/main/angular/src/app/components/wf-admin-panel/wf-admin-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/wf-admin-panel/wf-admin-panel.component.ts
@@ -23,7 +23,7 @@ export class WfAdminPanelComponent
 
   displayLabel = 'Simple Incidents Search';
   selectedFireCentreCode = '';
-  fireOfNotePublishedInd = true;
+  fireOfNotePublishedInd = false;
   fireCentreOptions = FireCentres;
 
   initModels() {


### PR DESCRIPTION
Updating the default query for incident search and fire type checkbox when initially landing on the admin page.
![image](https://github.com/user-attachments/assets/2dd8f379-49eb-4ca1-bdfd-ca06b5d748d4)
