### PR TITLE
WFNEWS-2493 adjust highlight card css for mobile

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/dashboard-component/widgets/cards/highlights-card/highlights-card.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/dashboard-component/widgets/cards/highlights-card/highlights-card.component.scss
@@ -6,6 +6,11 @@
 }
 
 .highlight-card {
+    @media screen and (max-width: 500px) {
+        width: 50vw;
+        min-width: 100px;
+        min-height: 370px;
+    }
     border-radius: var(--8, 8px);
     font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
     background: #f5f6f9;
@@ -58,6 +63,9 @@
 }
 
 .highlight-tags {
+    @media screen and (max-width: 500px) {
+        display: none;
+    }
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -93,4 +101,5 @@
     line-height: 19px;
     position: absolute;
     bottom: 16px;
+    right: 16px;
 }


### PR DESCRIPTION
Removed tags on screens < 500px width as multiple tags were pushing the title down and overlapping with the "Posted on" date. Keeping font size as indicated in the TAC.
Screenshots;
![image](https://github.com/user-attachments/assets/32b53de5-f19e-4720-8e0b-faf1b6233769)
![image](https://github.com/user-attachments/assets/b6938e99-c265-479f-b45c-ab6326164d62)
![image](https://github.com/user-attachments/assets/213b962a-c936-42b0-9fc0-3b1d17f64202)
![image](https://github.com/user-attachments/assets/4ddd1576-67d2-4a25-bdd4-97664097fc7f)



