### PR TITLE
implement fetch wildfire by bbox in area-restriction desktop detail page to show the assoicate wildfire

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-event-page/area-restriction-details/area-restriction-details.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-event-page/area-restriction-details/area-restriction-details.component.html
@@ -11,6 +11,10 @@
       <warning-card></warning-card>
     </ng-container>
     <ng-container column-2>
+      <associated-wildfire-card *ngIf="incident" [incident]="incident" [isBookmarked]="isBookmarked"
+        (bookmarkClicked)="handleBookmarkClicked($event)"
+        (viewDetailsClicked)="handleViewDetailsClicked()">
+      </associated-wildfire-card>
       <related-topics-card [links]="relatedTopicLinks"></related-topics-card>
     </ng-container>
   </two-column-content-cards-container>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-event-page/area-restriction-details/area-restriction-details.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-event-page/area-restriction-details/area-restriction-details.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AdvisorySectionStyle } from '@app/components/common/advisory-section/advisory-section.component';
 import { IconButtonArgs } from '@app/components/common/icon-button/icon-button.component';
 import { RelatedTopicsLink } from '@app/components/full-details/cards/related-topics-card/related-topics-card.component';
+import { SimpleIncident } from '@app/services/published-incident-service';
 import { AppConfigService } from '@wf1/core-ui';
 
 @Component({
@@ -12,6 +13,13 @@ import { AppConfigService } from '@wf1/core-ui';
 export class AreaRestrictionDetailsComponent {
 
   @Input() areaRestriction: any;
+  @Input() incident: SimpleIncident;
+  @Input() isBookmarked: boolean;
+
+  
+  @Output() bookmarkClicked = new EventEmitter<boolean>();
+
+  @Output() viewDetailsClicked = new EventEmitter<void>();
 
   advisorySectionComponentStyle: AdvisorySectionStyle = {
     backgroundColor: '#F0F5FF',
@@ -63,4 +71,13 @@ export class AreaRestrictionDetailsComponent {
   handleAdvisoryClick = () => {
     window.open(this.getBulletinLink(), '_blank');
   };
+
+  handleBookmarkClicked = ($event) => {
+    this.bookmarkClicked.emit($event);
+  };
+
+  handleViewDetailsClicked = () => {
+    this.viewDetailsClicked.emit();
+  };
+
 }

--- a/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.html
@@ -19,7 +19,11 @@
             (viewDetailsClicked)="handleViewDetailsClicked()"
         ></evac-order-details>
         <area-restriction-details *ngSwitchCase="'area-restriction'"
+            [incident]="incident"
             [areaRestriction]="areaRestriction"
+            [isBookmarked]="isAssociatedWildfireBookmarked"
+            (bookmarkClicked)="handleBookmarkClicked($event)"
+            (viewDetailsClicked)="handleViewDetailsClicked()"
         ></area-restriction-details>
         <fire-ban-details *ngSwitchCase="'ban'"
             [fireBan]="ban"

--- a/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.ts
@@ -103,7 +103,7 @@ export class PublicEventPageComponent {
                   this.cdr.detectChanges();
               } catch (error) {
                 console.error(
-                  'Error while populaiting associated incident for area restriction: ' +
+                  'Error while populating associated incident for area restriction: ' +
                     error,
                 );
               }

--- a/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-event-page/public-event-page.component.ts
@@ -18,7 +18,7 @@ export class PublicEventPageComponent {
   public id : string;
   public eventName: string;
   public evac: string;
-  public areaRestriction: string;
+  public areaRestriction: any;
   public ban: string;
   public dangerRating: string;
   public incident: SimpleIncident;
@@ -88,10 +88,27 @@ export class PublicEventPageComponent {
       },
     )
       .toPromise()
-      .then((response) => {
+      .then(async (response) => {
         if (response?.features?.length > 0 && response?.features[0].geometry?.rings?.length > 0) {
           this.areaRestriction = response.features[0];
           this.isLoading = false;
+            if (this.areaRestriction) {
+              const restrictionPolygon = this.areaRestriction.geometry.rings;
+              try {
+                this.incident =
+                  await this.publishedIncidentService.populateIncidentByPoint(
+                    restrictionPolygon,
+                  );
+                  this.isAssociatedWildfireBookmarked = this.onWatchlist(this.incident);
+                  this.cdr.detectChanges();
+              } catch (error) {
+                console.error(
+                  'Error while populaiting associated incident for area restriction: ' +
+                    error,
+                );
+              }
+            
+            }
         }
       });
   }


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WFNEWS-2512
This feature was missing in evac detail page 
![image](https://github.com/user-attachments/assets/2778588b-e010-4f75-8e03-5a3e774dfba6)
