### PR TITLE
fix the method for tab to pass value to snowplow

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-header/incident-header-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/incident-info-header/incident-header-panel.component.ts
@@ -692,10 +692,6 @@ export class IncidentHeaderPanelComponent implements AfterViewInit, OnInit {
     }
   }
 
-  // printPage(){
-  //   this.requestPrint.emit();
-  // }
-
   public printPage() {
     const twoColumnContent = document.getElementsByClassName('two-column-content-cards-container')[0];
     twoColumnContent.classList.add('print');

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.html
@@ -16,7 +16,7 @@
       </app-incident-tabs>
     </div>
     <div *ngIf="hideOnMobileView()">
-      <mat-tab-group mat-stretch-tabs-mobile [headerPosition]="above">
+      <mat-tab-group mat-stretch-tabs-mobile [headerPosition]="above" (selectedIndexChange)="onTabChange($event)">
         <mat-tab label="Details">
           <incident-info-panel-mobile *ngIf="hideOnMobileView()" [incident]="incident" [evacOrders]="evacOrders" [areaRestrictions]="areaRestrictions"></incident-info-panel-mobile>
         </mat-tab>

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
@@ -294,19 +294,27 @@ export class PublicIncidentPageComponent implements OnInit {
     window.location.href = mailtoUrl;
   }
 
-  onTabChange(event: MatTabChangeEvent) {
+  onTabChange(event: MatTabChangeEvent | number): void {
+    const tabLabels = ['Details', 'Response', 'Gallery', 'Maps'];
     const url = this.appConfigService.getConfig().application.baseUrl.toString() + this.currentRouter.url.slice(1);
+  
+    // Determine the index based on the type of event
+    const index = typeof event === 'number' ? event : event.index;
+  
     let actionName;
-    if (event?.tab?.textLabel === 'Response') {
+    if (index === 0) {
+      actionName = 'incident_details_details_click';
+    } else if (index === 1) {
       actionName = 'incident_details_response_click';
-    } else if (event?.tab?.textLabel === 'Gallery') {
+    } else if (index === 2) {
       actionName = 'incident_details_gallery_click';
-    } else if (event?.tab?.textLabel === 'Maps') {
+    } else if (index === 3) {
       actionName = 'incident_details_maps_click';
     }
+  
     this.snowPlowHelper(url, {
       action: actionName,
-      text: event?.tab?.textLabel
+      text: tabLabels[index]
     });
   }
 }

--- a/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/public-incident-page/public-incident-page.component.ts
@@ -16,6 +16,7 @@ import { findFireCentreByName, hideOnMobileView } from '../../utils';
   templateUrl: './public-incident-page.component.html',
   styleUrls: ['./public-incident-page.component.scss'],
 })
+
 export class PublicIncidentPageComponent implements OnInit {
   public isLoading = true;
   public loadingFailed = false;
@@ -35,7 +36,6 @@ export class PublicIncidentPageComponent implements OnInit {
 
   findFireCentreByName = findFireCentreByName;
   hideOnMobileView = hideOnMobileView;
-
   constructor(
     private router: ActivatedRoute,
     protected cdr: ChangeDetectorRef,
@@ -295,26 +295,30 @@ export class PublicIncidentPageComponent implements OnInit {
   }
 
   onTabChange(event: MatTabChangeEvent | number): void {
+    const TAB_ACTIONS = [
+      'incident_details_details_click',
+      'incident_details_response_click',
+      'incident_details_gallery_click',
+      'incident_details_maps_click',
+    ];
+  
     const tabLabels = ['Details', 'Response', 'Gallery', 'Maps'];
     const url = this.appConfigService.getConfig().application.baseUrl.toString() + this.currentRouter.url.slice(1);
   
     // Determine the index based on the type of event
     const index = typeof event === 'number' ? event : event.index;
   
-    let actionName;
-    if (index === 0) {
-      actionName = 'incident_details_details_click';
-    } else if (index === 1) {
-      actionName = 'incident_details_response_click';
-    } else if (index === 2) {
-      actionName = 'incident_details_gallery_click';
-    } else if (index === 3) {
-      actionName = 'incident_details_maps_click';
+    // Validate the index to avoid accessing undefined values
+    if (index < 0 || index >= TAB_ACTIONS.length) {
+      console.warn('Invalid tab index:', index);
+      return;
     }
   
+    const actionName = TAB_ACTIONS[index];
     this.snowPlowHelper(url, {
       action: actionName,
-      text: tabLabels[index]
+      text: tabLabels[index],
     });
   }
+  
 }


### PR DESCRIPTION
When using a custom template for labels (<ng-template mat-tab-label>), Angular Material does not populate the tab.textLabel property. Therefore, tab.textLabel is often undefined or an empty string.