### PR TITLE
adjust the evac card height in dashboard accordingly

### DIFF
--- a/client/wfnews-war/src/main/angular/src/app/components/dashboard-component/widgets/evacuations-widget/evacuations-widget.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/dashboard-component/widgets/evacuations-widget/evacuations-widget.component.scss
@@ -6,7 +6,8 @@
     overflow: hidden;
     font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
     display: flex;
-    height: 640px;
+    min-height: 540px;
+    height: fit-content;
     max-height: 640px;
     padding: var(--24, 24px);
     flex-direction: column;
@@ -101,7 +102,7 @@
     overflow: hidden;
     font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
     display: flex;
-    height: 640px;
+    height: fit-content;
     max-width: 850px;
     max-height: 640px;
     padding: var(--24, 24px);
@@ -197,7 +198,7 @@
     overflow: hidden;
     font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
     display: flex;
-    height: 558px;
+    height: fit-content;
     flex-direction: column;
     align-items: flex-start;
     gap: 12px;


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WFNEWS-2057

in desktop full view it will need 540px height to match the widget next to it. 
in tablet screen and mobile screen it should fit content beacuast there will only be one column in dashboard