### PR TITLE
Clean up situation report tables and add a pk

### DIFF
--- a/database/main-changelog.json
+++ b/database/main-changelog.json
@@ -345,6 +345,36 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "01_01_00_00",
+        "author": "sparmar",
+        "changes": [
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_01_00/00/dml/CLEANUP.SITUATION_REPORT.sql"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "01_01_00_01",
+        "author": "sparmar",
+        "changes": [
+          {
+            "sqlFile": {
+              "dbms": "postgresql",
+              "endDelimiter": ";",
+              "path": "scripts/01_01_00/00/ddl/tables/ALTER.SITUATION_REPORT.sql"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/database/scripts/01_01_00/00/ddl/tables/ALTER.SITUATION_REPORT.sql
+++ b/database/scripts/01_01_00/00/ddl/tables/ALTER.SITUATION_REPORT.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "wfnews"."situation_report" 
+ADD CONSTRAINT situation_report_pk PRIMARY KEY (report_guid);

--- a/database/scripts/01_01_00/00/dml/CLEANUP.SITUATION_REPORT.sql
+++ b/database/scripts/01_01_00/00/dml/CLEANUP.SITUATION_REPORT.sql
@@ -1,0 +1,6 @@
+DELETE FROM "wfnews"."situation_report"
+WHERE ctid NOT IN (
+    SELECT max(ctid)
+    FROM "wfnews"."situation_report"
+    GROUP BY report_guid
+);


### PR DESCRIPTION
Situation report table is missing a primary key and unique constraint. This leads to issues where there could be more than one copy of a situation report (especially after running a migration).

After moving to the LZA I noticed there were multiple copies of every record on this table.