### PR TITLE
WFNEWS-2801

### DIFF
--- a/client/wfnews-war/src/main/angular/package.json
+++ b/client/wfnews-war/src/main/angular/package.json
@@ -1,38 +1,10 @@
 {
-  "name": "wildfire",
-  "version": "2.5.1",
-  "license": "MIT",
-  "engines": {
-    "node": "^18.16.0"
-  },
   "browser": {
     "fs": false,
     "path": false,
     "os": false,
     "crypto": false
   },
-  "scripts": {
-    "ng": "ng",
-    "serve": "ng serve",
-    "serve.local.proxy": "ng serve --disableHostCheck true",
-    "start": "ng serve --proxy-config ../dm-proxy/proxy.conf.json",
-    "start.prod": "ng serve --configuration production",
-    "build": "ng build --source-map",
-    "build.prod": "ng build --source-map --configuration production --base-href / && replace-in-file /ngsw:/g ngsw:wfimi: dist/ngsw-worker.js --verbose --isRegex",
-    "build.mobile": "ng build --source-map --configuration mobile --base-href /",
-    "test": "ng test",
-    "lint": "ng lint WFNEWS",
-    "lint-fix": "ng lint WFNEWS --fix",
-    "prettier": "npx prettier . --write",
-    "clean": "npx prettier . --write && ng lint WFNEWS --fix",
-    "e2e": "ng e2e",
-    "cr": "npm run lint && npm start.prod",
-    "mavenbuild": "node --max_old_space_size=4096 node_modules/@angular/cli/bin/ng build --configuration production --output-path ../../../target/angular --base-href / && replace-in-file /ngsw:/g ngsw:wfnewsi: dist/ngsw-worker.js --verbose --isRegex",
-    "mavenbuild-source-map": "node --max_old_space_size=4096 node_modules/@angular/cli/bin/ng build --configuration production --output-path ../../../target/angular --base-href / --source-map && replace-in-file /ngsw:/g ngsw:wfnewsi: ../../../target/angular/ngsw-worker.js --verbose --isRegex",
-    "storybook": "ng run WFNEWS:storybook",
-    "build-storybook": "ng run WFNEWS:build-storybook"
-  },
-  "private": true,
   "dependencies": {
     "@angular/animations": "15.2.9",
     "@angular/cdk": "15.2.9",
@@ -85,7 +57,7 @@
     "@swimlane/ngx-charts": "20.1.0",
     "@types/geojson": "7946.0.8",
     "@wf1/core-ui": "^2.4.5",
-    "@wf1/incidents-rest-api": "^1.9.0-SNAPSHOT",
+    "@wf1/incidents-rest-api": "^1.10.0-SNAPSHOT",
     "@wf1/orgunit-rest-api": "^2.0.2",
     "@wf1/wfcc-application-ui": "^1.2.0-SNAPSHOT",
     "@wf1/wfdm-document-management-api": "^1.2.0-SNAPSHOT",
@@ -177,5 +149,33 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
     "webpack": "^5.91.0"
-  }
+  },
+  "engines": {
+    "node": "^18.16.0"
+  },
+  "license": "MIT",
+  "name": "wildfire",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "serve": "ng serve",
+    "serve.local.proxy": "ng serve --disableHostCheck true",
+    "start": "ng serve --proxy-config ../dm-proxy/proxy.conf.json",
+    "start.prod": "ng serve --configuration production",
+    "build": "ng build --source-map",
+    "build.prod": "ng build --source-map --configuration production --base-href / && replace-in-file /ngsw:/g ngsw:wfimi: dist/ngsw-worker.js --verbose --isRegex",
+    "build.mobile": "ng build --source-map --configuration mobile --base-href /",
+    "test": "ng test",
+    "lint": "ng lint WFNEWS",
+    "lint-fix": "ng lint WFNEWS --fix",
+    "prettier": "npx prettier . --write",
+    "clean": "npx prettier . --write && ng lint WFNEWS --fix",
+    "e2e": "ng e2e",
+    "cr": "npm run lint && npm start.prod",
+    "mavenbuild": "node --max_old_space_size=4096 node_modules/@angular/cli/bin/ng build --configuration production --output-path ../../../target/angular --base-href / && replace-in-file /ngsw:/g ngsw:wfnewsi: dist/ngsw-worker.js --verbose --isRegex",
+    "mavenbuild-source-map": "node --max_old_space_size=4096 node_modules/@angular/cli/bin/ng build --configuration production --output-path ../../../target/angular --base-href / --source-map && replace-in-file /ngsw:/g ngsw:wfnewsi: ../../../target/angular/ngsw-worker.js --verbose --isRegex",
+    "storybook": "ng run WFNEWS:storybook",
+    "build-storybook": "ng run WFNEWS:build-storybook"
+  },
+  "version": "2.5.2"
 }

--- a/client/wfnews-war/src/main/angular/src/app/app.module.ts
+++ b/client/wfnews-war/src/main/angular/src/app/app.module.ts
@@ -304,6 +304,7 @@ import { IncidentContainerDesktop } from './containers/incident/incident-contain
 import { PanelWildfireStageOfControlContainerDesktop } from './containers/panelWildfireStageOfControl/panelWildfireStageOfControl-container.component.desktop';
 import { WildfiresListContainerDesktop } from './containers/wildfiresList/wildfiresList-container.component.desktop';
 import { SingleSelectDirective } from './directives/singleselect.directive';
+import { WfimEtagInterceptor } from './interceptors/wfim-etag-interceptor';
 import { WfnewsInterceptor } from './interceptors/wfnews-interceptor';
 import { SafePipe } from './pipes/safe.pipe';
 import { AGOLService } from './services/AGOL-service';
@@ -710,6 +711,11 @@ export const DATE_FORMATS = {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: WfnewsInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: WfimEtagInterceptor,
       multi: true,
     },
     { provide: MAT_DIALOG_DATA, useValue: {} },

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/evac-orders-details-panel/evac-orders-details-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/evac-orders-details-panel/evac-orders-details-panel.component.ts
@@ -7,9 +7,9 @@ import {
 import { EvacOrderOption } from '../../../conversion/models';
 import { AGOLService } from '../../../services/AGOL-service';
 import {
-  DefaultService as ExternalUriService,
   ExternalUriResource,
 } from '@wf1/incidents-rest-api';
+import { WfimExternalUriService as ExternalUriService } from '../../../services/wfim-external-uri.service';
 
 @Component({
   selector: 'evac-orders-details-panel',
@@ -76,12 +76,11 @@ export class EvacOrdersDetailsPanel implements OnInit {
     this.evacOrderForm.removeAt(index);
     // delete from externalUri, if this uri already exists
     if (evac?.externalUri?.externalUriGuid) {
-      this.externalUriService
-        .deleteExternalUri(evac.externalUri.externalUriGuid)
-        .toPromise()
-        .catch((err) => {
-          console.error(err);
-        });
+      const guid = evac.externalUri.externalUriGuid;
+      const etag = evac.externalUri.etag || evac.externalUri['@etag'];
+      this.externalUriService.deleteExternalUri(guid, etag).catch((err) => {
+        console.error(err);
+      });
     }
     this.cdr.detectChanges();
   }
@@ -101,12 +100,10 @@ export class EvacOrdersDetailsPanel implements OnInit {
 
       if (evac.externalUri?.externalUriGuid) {
         await this.externalUriService
-          .updateExternalUri(evac.externalUri.externalUriGuid, evac.externalUri)
-          .toPromise();
+          .updateExternalUri(evac.externalUri.externalUriGuid, evac.externalUri);
       } else {
         await this.externalUriService
-          .createExternalUri(evac.externalUri)
-          .toPromise();
+          .createExternalUri(evac.externalUri);
       }
     }
   }
@@ -133,15 +130,11 @@ export class EvacOrdersDetailsPanel implements OnInit {
     this.externalUriService
       .getExternalUriList(
         '' + this.incident.wildfireIncidentGuid,
-        '' + 1,
-        '' + 100,
-        'response',
-        undefined,
-        undefined,
+        1,
+        100
       )
-      .toPromise()
       .then((response) => {
-        const externalUriList = response.body;
+        const externalUriList = response;
         for (const uri of externalUriList.collection) {
           if (uri.externalUriCategoryTag.includes('EVAC-ORDER')) {
             const evac = {

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/image-gallery-panel/image-gallery-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/image-gallery-panel/image-gallery-panel.component.ts
@@ -8,11 +8,11 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import {
-  DefaultService as ExternalUriService,
   DefaultService as IncidentAttachmentsService,
   DefaultService as IncidentAttachmentService,
   AttachmentResource,
 } from '@wf1/incidents-rest-api';
+import { WfimExternalUriService as ExternalUriService } from '../../../services/wfim-external-uri.service';
 import { BaseComponent } from '../../base/base.component';
 import { Overlay } from '@angular/cdk/overlay';
 import { HttpClient } from '@angular/common/http';
@@ -168,16 +168,12 @@ return 0;
     this.externalUriService
       .getExternalUriList(
         '' + this.incident.wildfireIncidentGuid,
-        '' + 1,
-        '' + 100,
-        'response',
-        undefined,
-        undefined,
+        1,
+        100
       )
-      .toPromise()
       .then((response) => {
         this.externalUriList = [];
-        const uris = response.body;
+        const uris = response;
         for (const uri of uris.collection) {
           if (
             uri.externalUriCategoryTag.includes('video') &&
@@ -356,7 +352,6 @@ return 0;
         videoLink.primaryInd = false;
         await this.externalUriService
           .updateExternalUri(videoLink.externalUriGuid, videoLink)
-          .toPromise()
           .catch((err) => {
             // Ignore this
             console.error(err);

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.html
@@ -4,7 +4,7 @@
     <button mat-button color="primary" class="primary-button" (click)="upload()">Upload Map</button>
   </div>
   <div class="table-wrapper flex-y-grow" *ngIf="attachments; else loading">
-    <table style = "width: fit-content;" mat-table matSort [dataSource]="attachments"
+    <table style="width: 100%;" mat-table matSort [dataSource]="attachments"
             [matSortActive]="this.searchState.sortParam"
             [matSortDirection]="this.searchState.sortDirection.toLowerCase()"
             (matSortChange)="sortData($event)"

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.scss
@@ -7,11 +7,6 @@
   }
 }
 
-div {
-  margin-left: 2%;
-  margin-right: 2%;
-}
-
 p.dashboard-title {
   font-size: 35px;
   margin-bottom: 0.5%;
@@ -29,13 +24,6 @@ p.datetime {
 
 tr {
   font-weight: normal;
-}
-
-table {
-  border: 1;
-  width: 96%;
-  margin-left: 2%;
-  margin-right: 2%;
 }
 
 td {
@@ -110,18 +98,17 @@ table tr:nth-child(even) td {
     td,
     th {
       word-wrap: break-word;
+      word-break: break-all;
       vertical-align: middle;
       overflow: hidden;
       text-overflow: ellipsis;
-      flex: 1 1 100px;
-      max-width: 100px;
     }
 
     th {
       font-family: $font-family-emphasis;
     }
     td {
-      white-space: nowrap;
+      white-space: normal;
     }
 
     td.border-left,
@@ -143,6 +130,18 @@ table tr:nth-child(even) td {
 
       div {
         line-height: 12px;
+      }
+    }
+
+    .mat-column-edit,
+    .mat-column-download,
+    .mat-column-delete {
+      width: 100px;
+      text-align: center;
+      padding: 0;
+
+      mat-icon {
+        margin: 0 auto;
       }
     }
   }
@@ -507,7 +506,7 @@ table tr:nth-child(even) td {
 }
 
 .header-panel {
-  padding: 10px;
+  padding: 1rem 2rem;
   display: flex;
 }
 

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/maps-panel/maps-panel.component.ts
@@ -1,3 +1,5 @@
+import { Overlay } from '@angular/cdk/overlay';
+import { HttpClient } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -7,15 +9,6 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
-import {
-  DefaultService as IncidentAttachmentsService,
-  DefaultService as IncidentAttachmentService,
-  AttachmentResource,
-} from '@wf1/incidents-rest-api';
-import { BaseComponent } from '../../base/base.component';
-import * as moment from 'moment';
-import { Overlay } from '@angular/cdk/overlay';
-import { HttpClient } from '@angular/common/http';
 import { UntypedFormBuilder } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import {
@@ -24,16 +17,23 @@ import {
   TextOnlySnackBar,
 } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
-import { Router, ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { AppConfigService, TokenService } from '@wf1/core-ui';
+import {
+  AttachmentResource,
+  DefaultService as IncidentAttachmentService,
+  DefaultService as IncidentAttachmentsService,
+} from '@wf1/incidents-rest-api';
+import * as moment from 'moment';
 import { ApplicationStateService } from '../../../services/application-state.service';
+import { DocumentManagementService } from '../../../services/document-management.service';
+import { WatchlistService } from '../../../services/watchlist-service';
 import { RootState } from '../../../store';
+import { BaseComponent } from '../../base/base.component';
 import { MessageDialogComponent } from '../../message-dialog/message-dialog.component';
 import { EditMapDialogComponent } from './edit-map-dialog/edit-map-dialog.component';
 import { UploadMapDialogComponent } from './upload-map-dialog/upload-map-dialog.component';
-import { DocumentManagementService } from '../../../services/document-management.service';
-import { WatchlistService } from '../../../services/watchlist-service';
 
 @Component({
   selector: 'maps-panel',
@@ -132,14 +132,14 @@ export class MapsPanel extends BaseComponent implements OnInit, OnChanges {
         docs.collection.sort((a, b) => {
           const dir = this.searchState.sortDirection === 'desc' ? -1 : 1;
           if (a[this.searchState.sortParam] < b[this.searchState.sortParam]) {
-return -dir;
-} else if (
+            return -dir;
+          } else if (
             a[this.searchState.sortParam] > b[this.searchState.sortParam]
           ) {
-return dir;
-} else {
-return 0;
-}
+            return dir;
+          } else {
+            return 0;
+          }
         });
         // remove any non-pdf types
         for (const doc of docs.collection) {
@@ -382,6 +382,8 @@ return 0;
             this.incident.wildfireYear,
             this.incident.incidentNumberSequence,
             item.attachmentGuid,
+            undefined,
+            item.etag || item['@etag'],
           )
           .toPromise()
           .then(() => {
@@ -389,8 +391,15 @@ return 0;
               duration: 10000,
               panelClass: 'snackbar-success',
             });
-            this.loaded = false;
-            this.cdr.detectChanges();
+
+            // Remove from table so it doesn't look like call failed
+            const index = this.attachments.findIndex(a => a.attachmentGuid === item.attachmentGuid);
+            if (index > -1) {
+              this.attachments.splice(index, 1);
+            }
+
+            // Trigger loadPage right away to keep server data synced
+            this.loadPage();
           })
           .catch((err) => {
             this.snackbarService.open(

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.html
@@ -1,9 +1,7 @@
 <div class="image-panel">
   <div class="image-container">
-    <div style="width: 650px;">
-      <iframe [src]="getSafeUrl(video.externalUri)" style="width: 400px; height: 250px; border: 0;" allowfullscreen>
-      </iframe>
-    </div>
+    <iframe [src]="getSafeUrl(video.externalUri)" style="width: calc(100% - 15px); height: 100%; border: 0; border-radius: 10px;" allowfullscreen>
+    </iframe>
   </div>
   <div class="info-panel">
     <div class="row">Video Title: <strong>{{video.externalUriDisplayLabel}}</strong></div>

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.scss
@@ -1,17 +1,16 @@
 .image-panel {
   display: flex;
-  padding: 16px;
+  padding: 1rem;
   width: 650px;
-  margin: 16px;
+  margin: 0 1rem;
 
   .image-container {
     width: 60%;
     height: 250px;
-    padding: 7px;
 
     img {
-      max-width: 350px;
-      height: inherit;
+      width: calc(100% - 15px);
+      height: 100%;
       object-fit: cover;
       border-radius: 10px;
     }
@@ -21,6 +20,9 @@
     font-family: "BCSans", "Open Sans", Verdana, Arial, sans-serif;
     padding: 5px;
     width: 40%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
 
     .row {
       white-space: nowrap;
@@ -29,10 +31,21 @@
     }
 
     .action {
-      padding-top: 5px;
+      padding: 5px 0;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      
       mat-icon {
         cursor: pointer;
+        font-size: 20px;
+        width: 20px;
+        height: 20px;
       }
+    }
+
+    .checkbox-label {
+      padding-left: 4px;
     }
 
     .divider {

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-card-component/video-card-panel.component.ts
@@ -8,7 +8,7 @@ import {
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { YouTubeService } from '@app/services/youtube-service';
-import { DefaultService as ExternalUriService } from '@wf1/incidents-rest-api';
+import { WfimExternalUriService as ExternalUriService } from '@app/services/wfim-external-uri.service';
 import * as moment from 'moment';
 import { convertToYoutubeId } from '../../../../utils';
 import { EditVideoDialogComponent } from '../edit-video-dialog/edit-video-dialog.component';
@@ -90,9 +90,9 @@ export class VideoCardPanel {
   }
 
   remove() {
-    this.externalUriService
-      .deleteExternalUri(this.video.externalUriGuid, 'response')
-      .toPromise()
+    const guid = this.video.externalUriGuid;
+    const etag = this.video.etag || this.video['@etag'];
+    this.externalUriService.deleteExternalUri(guid, etag)
       .then(() => {
         this.snackbarService.open('Video Deleted Successfully', 'OK', {
           duration: 0,
@@ -116,16 +116,7 @@ export class VideoCardPanel {
     this.video.externalUriDisplayLabel = externalUriDisplayLabel;
 
     this.externalUriService
-      .updateExternalUri(this.video.externalUriGuid, this.video, 'response')
-      .toPromise()
-      .then(() => {
-        this.snackbarService.open('Video Updated Successfully', 'OK', {
-          duration: 0,
-          panelClass: 'snackbar-success',
-        });
-        this.loaded = false;
-        this.loadPage.emit();
-      })
+      .updateExternalUri(this.video.externalUriGuid, this.video)
       .catch((err) => {
         this.snackbarService.open(
           'Failed to Update Video: ' + JSON.stringify(err.message),
@@ -133,6 +124,15 @@ export class VideoCardPanel {
           { duration: 0, panelClass: 'snackbar-error' },
         );
         this.loaded = false;
+        throw err;
+      })
+      .then(() => {
+        this.snackbarService.open('Video Updated Successfully', 'OK', {
+          duration: 0,
+          panelClass: 'snackbar-success',
+        });
+        this.loaded = false;
+        this.loadPage.emit();
       });
   }
 

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.html
@@ -3,7 +3,7 @@
       <span style="font-size: 24px;">Videos</span>
       <button mat-button color="primary" class="primary-button" (click)="upload()">Add Video</button>
     </div>
-    <div class="image-gallery">
+    <div class="video-gallery">
       <video-card-panel *ngFor="let video of externalUriList.collection" [video]="video" [incident]="incident" (loadPage)="loadPage()" (removePrimaryFlags)="removePrimaryFlags($event)"></video-card-panel>
     </div>
   </ng-container>

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.scss
@@ -1,5 +1,5 @@
 .header-panel {
-  padding: 10px;
+  padding: 1rem 2rem;
   display: flex;
 }
 
@@ -9,7 +9,7 @@
   color: white;
 }
 
-.image-gallery {
+.video-gallery {
   display: flex;
   flex-flow: row;
   flex-wrap: wrap;

--- a/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.ts
+++ b/client/wfnews-war/src/main/angular/src/app/components/admin-incident-form/video-gallery-panel/video-gallery-panel.component.ts
@@ -8,10 +8,10 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import {
-  DefaultService as ExternalUriService,
   DefaultService as IncidentAttachmentService,
   ExternalUriResource,
 } from '@wf1/incidents-rest-api';
+import { WfimExternalUriService as ExternalUriService } from '../../../services/wfim-external-uri.service';
 import { BaseComponent } from '../../base/base.component';
 import { Overlay } from '@angular/cdk/overlay';
 import { HttpClient } from '@angular/common/http';
@@ -107,16 +107,12 @@ export class VideoGalleryPanel
     this.externalUriService
       .getExternalUriList(
         '' + this.incident.wildfireIncidentGuid,
-        '' + 1,
-        '' + 100,
-        'response',
-        undefined,
-        undefined,
+        1,
+        100
       )
-      .toPromise()
       .then((response) => {
         this.externalUriList.collection = [];
-        const uris = response.body;
+        const uris = response;
         for (const uri of uris.collection) {
           if (uri.externalUriCategoryTag.includes('video')) {
             this.externalUriList.collection.push(uri);
@@ -263,8 +259,7 @@ return 0;
       } as ExternalUriResource;
 
       return this.externalUriService
-        .createExternalUri(resource, 'response')
-        .toPromise();
+        .createExternalUri(resource);
     }
   }
 
@@ -310,7 +305,6 @@ return 0;
         videoLink.primaryInd = false;
         await this.externalUriService
           .updateExternalUri(videoLink.externalUriGuid, videoLink)
-          .toPromise()
           .catch((err) => {
             // Ignore this
             console.error(err);

--- a/client/wfnews-war/src/main/angular/src/app/components/message-dialog/message-dialog.component.html
+++ b/client/wfnews-war/src/main/angular/src/app/components/message-dialog/message-dialog.component.html
@@ -1,10 +1,8 @@
-<div class="error-dialog">
-  <h1>{{data.title}}</h1>
-	<div class="message">
-		<strong>{{data.message}}</strong>
-	</div>
-  <div mat-dialog-actions>
-  	<button mat-raised-button color="primary" [mat-dialog-close]="true">Ok</button>
-	  <button mat-raised-button color="warn" [mat-dialog-close]="false">Cancel</button>
-  </div>
+<div class="content">
+    <div class="title"> {{data.title}} </div>
+    <p><strong>{{data.message}}</strong></p>
+    <div class="button-group">
+        <button class="btn-block secondary" [mat-dialog-close]="false"> Cancel </button>
+        <button class="btn-block primary" [mat-dialog-close]="true"> Confirm </button>
+    </div>
 </div>

--- a/client/wfnews-war/src/main/angular/src/app/components/message-dialog/message-dialog.component.scss
+++ b/client/wfnews-war/src/main/angular/src/app/components/message-dialog/message-dialog.component.scss
@@ -1,13 +1,58 @@
-.error-dialog {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  font-family: "BCSans", "Open Sans", Verdana, Arial, sans-serif;
-
-  h1 {
-    color: #ff4545;
-    font-size: large;
+.content {
+  padding: 24px;
+  .title {
+    font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
     text-align: center;
+  }
+  p {
+    color: #6e6e6e;
+    font-family: "Noto sans", "BCSans", "Open Sans", Verdana, Arial, sans-serif;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    text-align: center;
+  }
+  .button-group {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    button {
+      border-radius: 5px;
+      padding: 8px;
+      cursor: pointer;
+    }
+  }
+
+  .btn-block {
+    flex-grow: 1;
+    margin: 5px;
+    height: 38px;
+    width: calc(80vw - 48px);
+    border-radius: 5px;
+    border: 1px solid #c7c7c7;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+  }
+  .primary {
+    color: #fff;
+    background: #123262;
+  }
+
+  .delete {
+    color: #fff;
+    background: #b93237;
+  }
+
+  .secondary {
+    color: #000;
+    background: #f5f5f5;
   }
 }

--- a/client/wfnews-war/src/main/angular/src/app/interceptors/wfim-etag-interceptor.ts
+++ b/client/wfnews-war/src/main/angular/src/app/interceptors/wfim-etag-interceptor.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpResponse
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { filter, switchMap } from 'rxjs/operators';
+import { AppConfigService } from '@wf1/core-ui';
+
+@Injectable()
+export class WfimEtagInterceptor implements HttpInterceptor {
+
+  constructor(private appConfig: AppConfigService) {}
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const config = this.appConfig.getConfig();
+    const incidentsUrl = config && config.rest ? config.rest['incidents'] : null;
+    
+    // Only intercept modifying requests destined for the WFIM API
+    if (incidentsUrl && (request.method === 'PUT' || request.method === 'POST' || request.method === 'DELETE') && request.url.startsWith(incidentsUrl)) {
+      
+      const etag = request.body && typeof request.body === 'object' ? (request.body['etag'] || request.body['@etag']) : null;
+      const hasValidIfMatch = request.headers.has('If-Match') && request.headers.get('If-Match') !== '[object Object]';
+
+      if (hasValidIfMatch) {
+         return next.handle(request);
+      }
+
+      if (etag) {
+        const cloned = request.clone({
+          headers: request.headers.set('If-Match', String(etag))
+        });
+        return next.handle(cloned);
+      }
+      
+      // If no ETag is available, but this is a PUT or DELETE request, we MUST fetch it 
+      // (because list endpoints strip ETags, rendering optimistic locking impossible from UI)
+      if (!etag && (request.method === 'PUT' || request.method === 'DELETE')) {
+         const getRequest = request.clone({ method: 'GET', body: null });
+         
+         return next.handle(getRequest).pipe(
+            filter((event: HttpEvent<any>) => event instanceof HttpResponse),
+            switchMap((response: any) => {
+               const fetchedEtag = response.headers?.get('ETag') || response.body?.['@etag'] || response.body?.['etag'];
+               
+               if (fetchedEtag) {
+                  let newBody = request.body;
+                  // Some endpoints also require the ETag inside the JSON body itself
+                  if (request.method === 'PUT' && request.body && typeof request.body === 'object') {
+                     newBody = { ...request.body, etag: fetchedEtag };
+                  }
+                  
+                  const cloned = request.clone({
+                    body: newBody,
+                    headers: request.headers.set('If-Match', String(fetchedEtag))
+                  });
+                  return next.handle(cloned);
+               }
+               
+               // Fallback if ETag still isn't found
+               return next.handle(request);
+            })
+         );
+      }
+    }
+    
+    return next.handle(request);
+  }
+}

--- a/client/wfnews-war/src/main/angular/src/app/interceptors/wfnews-interceptor.ts
+++ b/client/wfnews-war/src/main/angular/src/app/interceptors/wfnews-interceptor.ts
@@ -129,7 +129,7 @@ export class WfnewsInterceptor
             processedRequest,
             requestId,
           );
-        this.handleError(errorHandlingInstructions);
+        this.handleError(errorHandlingInstructions, response.url);
         throw response;
       }),
     );
@@ -219,12 +219,18 @@ export class WfnewsInterceptor
       }
 
       return this.createErrorHandlingInstructions(null, null, message);
+    } else if (response.status === 412) {
+      return this.createErrorHandlingInstructions(
+        null,
+        null,
+        'This record has been modified by another user. Please refresh and try again.',
+      );
     }
 
     return null;
   }
 
-  handleError(errorHandlingInstructions: ErrorHandlingInstructions) {
+  handleError(errorHandlingInstructions: ErrorHandlingInstructions, errorUrl?: string) {
     if (!errorHandlingInstructions) {
       return;
     }
@@ -232,6 +238,17 @@ export class WfnewsInterceptor
     if (errorHandlingInstructions.redirectToRoute) {
       this.router.navigate([errorHandlingInstructions.redirectToRoute], {
         queryParams: { message: errorHandlingInstructions.redirectToRouteData },
+      });
+    }
+
+    const config = this.appConfig.getConfig();
+    const incidentsUrl = config && config.rest ? config.rest['incidents'] : null;
+    const isWfimApi = incidentsUrl && errorUrl && errorUrl.startsWith(incidentsUrl);
+
+    if (errorHandlingInstructions.snackBarErrorMsg && isWfimApi) {
+      this.snackbarService.open(errorHandlingInstructions.snackBarErrorMsg, 'OK', {
+        duration: 10000,
+        panelClass: 'snackbar-error'
       });
     }
   }

--- a/client/wfnews-war/src/main/angular/src/app/services/wfim-external-uri.service.ts
+++ b/client/wfnews-war/src/main/angular/src/app/services/wfim-external-uri.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { AppConfigService } from '@wf1/core-ui';
+import { ExternalUriResource } from '@wf1/incidents-rest-api';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WfimExternalUriService {
+  constructor(private http: HttpClient, private appConfig: AppConfigService) {}
+
+  private get basePath(): string {
+    return this.appConfig.getConfig().rest['incidents'];
+  }
+
+  public async getExternalUri(guid: string): Promise<any> {
+    return this.http.get(`${this.basePath}/externalUri/${guid}`, { observe: 'response' }).toPromise();
+  }
+
+  public async deleteExternalUri(guid: string, etag?: string): Promise<void> {
+    let headers = new HttpHeaders();
+    if (etag) {
+      headers = headers.set('If-Match', etag);
+    }
+    
+    await this.http.delete(`${this.basePath}/externalUri/${guid}`, { headers }).toPromise();
+  }
+
+  public async updateExternalUri(guid: string, resource: ExternalUriResource): Promise<any> {
+    // The WfimEtagInterceptor will automatically extract resource.etag and add the If-Match header
+    return this.http.put(`${this.basePath}/externalUri/${guid}`, resource).toPromise();
+  }
+
+  public createExternalUri(resource: ExternalUriResource): Promise<any> {
+    return this.http.post(`${this.basePath}/externalUri`, resource).toPromise();
+  }
+
+  public getExternalUriList(sourceObjectUniqueId: string, pageNumber: number = 1, pageRowCount: number = 100): Promise<any> {
+    return this.http.get(`${this.basePath}/externalUri`, {
+      params: {
+        sourceObjectUniqueId: sourceObjectUniqueId,
+        pageNumber: pageNumber.toString(),
+        pageRowCount: pageRowCount.toString()
+      }
+    }).toPromise();
+  }
+}


### PR DESCRIPTION
Pass the eTag if it has it, but if it doesn't then do a GET on the object and use that. This technically breaks the sync logic that the eTag is supposed to provide, but WFIM strips the eTags out of the list API and this is essentially how it was working before it broke.

Fix some of the styling and interactions around the updates and deletes like better message handling and UI so it doesn't seem broken when its not.